### PR TITLE
Upgrade to conform to M12

### DIFF
--- a/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_runtime_0_1_SNAPSHOT.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_runtime_0_1_SNAPSHOT.xml
@@ -2,10 +2,12 @@
   <library name="Gradle: org.jetbrains.kotlin:kotlin-runtime:0.1-SNAPSHOT">
     <CLASSES>
       <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-runtime/0.1-SNAPSHOT/e93c7e2f735b257ecbf7624fdd964120a14c7317/kotlin-runtime-0.1-SNAPSHOT.jar!/" />
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-runtime/0.1-SNAPSHOT/cafae9795b330599e7342bec4fd4e95dab273fad/kotlin-runtime-0.1-SNAPSHOT.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
       <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-runtime/0.1-SNAPSHOT/b344caed8ea5072a23741fd49b3d81061066617a/kotlin-runtime-0.1-SNAPSHOT-sources.jar!/" />
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-runtime/0.1-SNAPSHOT/321affb91c96a2a071b68521c7c2feefebfb5db4/kotlin-runtime-0.1-SNAPSHOT-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_0_1_SNAPSHOT.xml
+++ b/.idea/libraries/Gradle__org_jetbrains_kotlin_kotlin_stdlib_0_1_SNAPSHOT.xml
@@ -2,10 +2,12 @@
   <library name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:0.1-SNAPSHOT">
     <CLASSES>
       <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/0.1-SNAPSHOT/8cebbdc10724b0c4b5d30806f2f5aa4e609823b2/kotlin-stdlib-0.1-SNAPSHOT.jar!/" />
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/0.1-SNAPSHOT/42a6914bfc94f4bd6d777dc3f131d5dd33f613c5/kotlin-stdlib-0.1-SNAPSHOT.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
       <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/0.1-SNAPSHOT/b7eb4a567c4dff8830d070b860ab9ba49cc4ff18/kotlin-stdlib-0.1-SNAPSHOT-sources.jar!/" />
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/0.1-SNAPSHOT/486afd3067cf766b805d459efc7b8e663981de78/kotlin-stdlib-0.1-SNAPSHOT-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Actions.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Actions.kt
@@ -1,22 +1,22 @@
 package org.jetbrains.spek.api
 
 
-public trait TestSpekAction {
+public interface TestSpekAction {
     public fun description(): String
     public fun iterateGiven(it:(TestGivenAction) -> Unit)
 }
 
-public trait TestGivenAction {
+public interface TestGivenAction {
     public fun description(): String
     public fun iterateOn(it: (TestOnAction) -> Unit)
 }
 
-public trait TestOnAction {
+public interface TestOnAction {
     public fun description(): String
     public fun iterateIt(it : (TestItAction) -> Unit)
 }
 
-public trait TestItAction {
+public interface TestItAction {
     public fun description(): String
     public fun run()
 }

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Spek.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Spek.kt
@@ -4,7 +4,7 @@ import org.junit.runner.RunWith
 import org.jetbrains.spek.junit.*
 import org.jetbrains.spek.api.*
 
-RunWith(javaClass<JUnitClassRunner<*>>())
+RunWith(JUnitClassRunner::class)
 public abstract class Spek : org.jetbrains.spek.api.Specification {
 
     private val recordedActions = linkedListOf<org.jetbrains.spek.api.TestGivenAction>()

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Structure.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Structure.kt
@@ -1,18 +1,18 @@
 package org.jetbrains.spek.api
 
-public trait Specification {
+public interface Specification {
     public fun given(description: String, givenExpression: Given.() -> Unit)
 }
 
-public trait Given {
+public interface Given {
     public fun beforeOn(it: () -> Unit)
     public fun afterOn(it: () -> Unit)
     public fun on(description: String, onExpression: On.() -> Unit)
 }
 
-public trait On {
+public interface On {
     public fun it(description: String, itExpression: It.() -> Unit)
 }
 
-public trait It {}
+public interface It {}
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/ActionStatusReporter.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/ActionStatusReporter.kt
@@ -2,7 +2,7 @@ package org.jetbrains.spek.console
 
 import org.jetbrains.spek.api.*
 
-public trait ActionStatusReporter {
+public interface ActionStatusReporter {
     public fun started() {
     }
     public fun completed() {

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/ConsoleRunner.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/ConsoleRunner.kt
@@ -2,7 +2,7 @@ package org.jetbrains.spek.console
 
 
 public fun main(args: Array<String>)  {
-    if (args.size < 2) {
+    if (args.size() < 2) {
         printUsage()
     } else {
         try {
@@ -29,14 +29,14 @@ public fun getOptions(args: Array<String>): Options {
     var paths = listOf<String>()
     var packageName = ""
 
-    if (args.size > 0 ) {
+    if (args.size() > 0 ) {
         paths = args[0].split(',').toList()
     }
-    if (args.size > 1) {
+    if (args.size() > 1) {
         packageName = args[1]
     }
 
-    while (index < args.size) {
+    while (index < args.size()) {
         when (args[index]) {
             "-f", "--format" -> {
                 format = args[++index]

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/HTMLWorkflowReporter.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/HTMLWorkflowReporter.kt
@@ -4,7 +4,7 @@ public class HtmlWorkflowReporter(val suite: String, val device: OutputDevice, v
     //TODO: could use markdown + js
     var css = ""
 
-    {
+    init {
         if (cssFile != "") {
             css = "<link rel=\"stylesheet\" type=\"text/css\" href=\"$cssFile\">"
         }

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/OutputDevices.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/OutputDevices.kt
@@ -2,7 +2,7 @@ package org.jetbrains.spek.console
 
 import java.io.*
 
-public trait OutputDevice {
+public interface OutputDevice {
     public fun output(message: String)
 }
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/Reflection.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/Reflection.kt
@@ -6,9 +6,7 @@ public fun <T : Annotation> getAnnotation(element: AnnotatedElement, clazz: Clas
     //Dirty workaround for KT-3534
     if (!javaClass<Annotation>().isAssignableFrom(clazz))
         throw RuntimeException("$clazz must be an annotation")
-    val annotation = element.getAnnotation(clazz)
-    if (annotation == null)
-        return null
+    val annotation = element.getAnnotation(clazz) ?: return null
     return clazz.cast(annotation)
 }
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/WorkflowReporter.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/WorkflowReporter.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.spek.console
 
-public trait WorkflowReporter {
+public interface WorkflowReporter {
     public fun spek(spek: String): ActionStatusReporter
     public fun given(spek: String, given: String): ActionStatusReporter
     public fun on(spek: String, given: String, on: String): ActionStatusReporter

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/junit/JUnitClassRunner.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/junit/JUnitClassRunner.kt
@@ -9,7 +9,7 @@ import org.jetbrains.spek.*
 import org.jetbrains.spek.api.*
 
 data class JUnitUniqueId(val id: Int) : Serializable {
-    class object {
+    companion object {
         var id = 0
         fun next() = JUnitUniqueId(id++)
     }
@@ -97,7 +97,7 @@ public class JUnitGivenRunner<T>(val specificationClass: Class<T>, val given: Te
 
     protected override fun runChild(child: JUnitOnRunner<T>?, notifier: RunNotifier?) {
         junitAction(describeChild(child)!!, notifier!!) {
-            child!!.run(notifier!!)
+            child!!.run(notifier)
         }
     }
 }
@@ -123,7 +123,7 @@ public class JUnitClassRunner<T>(val specificationClass: Class<T>) : ParentRunne
 
     protected override fun runChild(child: JUnitGivenRunner<T>?, notifier: RunNotifier?) {
         junitAction(describeChild(child)!!, notifier!!) {
-            child!!.run(notifier!!)
+            child!!.run(notifier)
         }
     }
 }

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleCalculatorConsoleTest.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleCalculatorConsoleTest.kt
@@ -3,7 +3,8 @@ package org.jetbrains.spek.samples
 import org.jetbrains.spek.api.*
 import org.jetbrains.spek.samples.SampleCalculator
 
-class CalculatorConsoleSpecs: org.jetbrains.spek.api.Spek() {{
+class CalculatorConsoleSpecs: org.jetbrains.spek.api.Spek() {
+    init {
     given("a calculator") {
         val calculator = SampleCalculator()
         on("calling sum with two numbers") {

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleCalculatorJUnitTest.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleCalculatorJUnitTest.kt
@@ -5,7 +5,8 @@ import org.jetbrains.spek.junit.*
 import org.jetbrains.spek.api.*
 import org.jetbrains.spek.samples.SampleCalculator
 
-class CalculatorJUnitSpecs: org.jetbrains.spek.api.Spek() {{
+class CalculatorJUnitSpecs: org.jetbrains.spek.api.Spek() {
+    init {
     given("a calculator") {
         val calculator = SampleCalculator()
         on("calling sum with two numbers") {

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleIncUtilConsoleTest.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleIncUtilConsoleTest.kt
@@ -2,7 +2,8 @@ package org.jetbrains.spek.samples
 
 import org.jetbrains.spek.api.*
 
-public class IncUtilConsoleSpecs: Spek() {{
+public class IncUtilConsoleSpecs: Spek() {
+    init {
     given("an inc util") {
 
         val incUtil = SampleIncUtil()

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleIncUtilJUnitTest.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleIncUtilJUnitTest.kt
@@ -2,7 +2,8 @@ package org.jetbrains.spek.samples
 
 import org.jetbrains.spek.api.*
 
-class IncUtilJUnitSpecs: Spek() {{
+class IncUtilJUnitSpecs: Spek() {
+    init {
     given("an inc util") {
 
         val incUtil = SampleIncUtil()

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/Samples.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/Samples.kt
@@ -11,7 +11,8 @@ class SampleIncUtil {
     fun incValueBy(value: Int, inc: Int) = value + inc
 }
 
-class ba: Spek() { {
+class ba: Spek() {
+    init {
 
     given("abc") {
         beforeOn { println("before") }

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SkipSampleTest.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SkipSampleTest.kt
@@ -2,7 +2,8 @@ package org.jetbrains.spek.samples
 
 import org.jetbrains.spek.api.*
 
-class SkipSample: Spek() {{
+class SkipSample: Spek() {
+    init {
     given("a sample") {
         on("calling a function") {
             val result = 10

--- a/spek-samples/src/test/kotlin/RunSamplesInJUnitTest.kt
+++ b/spek-samples/src/test/kotlin/RunSamplesInJUnitTest.kt
@@ -17,6 +17,6 @@ public class RunSamplesInJUnitTest {
     }
 
     test fun try_console() {
-        main(array(".", "org.jetbrains.spek.samples", "-f", "text"))
+        main(arrayOf(".", "org.jetbrains.spek.samples", "-f", "text"))
     }
 }

--- a/spek-samples/src/test/kotlin/Tester.kt
+++ b/spek-samples/src/test/kotlin/Tester.kt
@@ -3,7 +3,8 @@ package org.jetbrains.spek.samples
 import org.jetbrains.spek.api.Spek
 
 
-class TimingSpecification: Spek() {{
+class TimingSpecification: Spek() {
+    init {
 
     given("something") {
         beforeOn({println("beforeOn")})

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/api/IntegrationTestCase.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/api/IntegrationTestCase.kt
@@ -12,15 +12,15 @@ public open class IntegrationTestCase {
     fun runTest(case: TestSpekAction, vararg expected: String) {
         val list = arrayListOf<String>()
         executeSpek(case, TestLogger(list))
-        if (expected.size == 0) return
+        if (expected.size() == 0) return
         val actualDump = list.map { it + "\n" }.fold("") { r, i -> r + i }
         val expectedLog = expected
                 .flatMap { it
                     .trim()
-                    .split("[\r\n]+")
+                    .split("[\r\n]+".toRegex())
                     .map { it.trim() }
-                    .filter { it.length > 0 }
-        } . filter { it.length > 0 }  . toList()
+                    .filter { it.length() > 0 }
+        } . filter { it.length() > 0 }  . toList()
 
         Assert.assertEquals(
                 actualDump,

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/api/OnBeforeAfterTest.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/api/OnBeforeAfterTest.kt
@@ -8,7 +8,8 @@ public class OnBeforeAfterTest : IntegrationTestCase() {
 
     test public fun callOnBefore() {
         val log = arrayListOf<String>()
-        runTest(object: Data() {{
+        runTest(object: Data() {
+            init {
             given("a") {
                 beforeOn { log add "before"}
                 on("1") {
@@ -23,7 +24,8 @@ public class OnBeforeAfterTest : IntegrationTestCase() {
 
     test public fun callOnAfter() {
         val log = arrayListOf<String>()
-        runTest(object: Data() {{
+        runTest(object: Data() {
+            init {
             given("a") {
                 afterOn { log add "after"}
                 on("1") {
@@ -38,7 +40,8 @@ public class OnBeforeAfterTest : IntegrationTestCase() {
 
     test public fun callOnBeforeAndOnAfter() {
         val log = arrayListOf<String>()
-        runTest(object : Data() {{
+        runTest(object : Data() {
+            init {
             given("a") {
                 beforeOn { log add "before"  }
                 afterOn { log add "after"  }

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/console/APITest.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/console/APITest.kt
@@ -15,7 +15,7 @@ public class APITest {
         spek.given("Third") {}
 
         //then there must be 3 TestGivenActions
-        assertEquals(3, spek.allGiven().size)
+        assertEquals(3, spek.allGiven().size())
         assertEquals("given First", spek.allGiven().get(0).description())
         assertEquals("given Second", spek.allGiven().get(1).description())
         assertEquals("given Third", spek.allGiven().get(2).description())


### PR DESCRIPTION
- replace trait with interface
- use size() and length() instead of length
- use split(Regex)
- use arrayOf() instead of array()
- upgrade companion object syntax
- upgrade initializer syntax (init keyword)