### PR TITLE
spek-41 init keyword is clunky

### DIFF
--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Spek.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Spek.kt
@@ -2,10 +2,12 @@ package org.jetbrains.spek.api
 
 import org.junit.runner.RunWith
 import org.jetbrains.spek.junit.*
-import org.jetbrains.spek.api.*
 
 @RunWith(JUnitClassRunner::class)
 public abstract class Spek : org.jetbrains.spek.api.Specification {
+    constructor(body: Spek.() -> Unit = {}) {
+        this.body()
+    }
 
     private val recordedActions = linkedListOf<org.jetbrains.spek.api.TestGivenAction>()
 

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleCalculatorConsoleTest.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleCalculatorConsoleTest.kt
@@ -1,10 +1,8 @@
 package org.jetbrains.spek.samples
 
-import org.jetbrains.spek.api.*
-import org.jetbrains.spek.samples.SampleCalculator
+import org.jetbrains.spek.api.shouldEqual
 
-class CalculatorConsoleSpecs: org.jetbrains.spek.api.Spek() {
-    init {
+class CalculatorConsoleSpecs: org.jetbrains.spek.api.Spek({
     given("a calculator") {
         val calculator = SampleCalculator()
         on("calling sum with two numbers") {
@@ -28,6 +26,5 @@ class CalculatorConsoleSpecs: org.jetbrains.spek.api.Spek() {
             }
         }
     }
-}
-}
+})
 


### PR DESCRIPTION
I added constructor to the ``Spek`` class with optional parameter that allow to create tests with the following syntax:
```
class SomeTest: Spek({
    give("...") {
        ...
    }
})
```
This parameter is optional so the backward compatibility is stored