### PR TITLE
Removed maven plugin

### DIFF
--- a/spek-dist/build.gradle
+++ b/spek-dist/build.gradle
@@ -1,7 +1,6 @@
 description = 'Spek Distribution packages'
 
 apply plugin: 'application'
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 


### PR DESCRIPTION
Hi

Since maven-publish plugin is already used having the maven plugin is not necessary. We had some users trying to install spek from JitPack.io and this small change makes it work.

Happy building!
