### PR TITLE
Added older and current versions of spek. (Update download.md)

### DIFF
--- a/download.md
+++ b/download.md
@@ -26,10 +26,13 @@ Download the latest artifacts from the [Build Server](http://teamcity.jetbrains.
 | [0.1.142](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.142) | 0.1.m9 | M9 | 
 | [0.1.145](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.145) | 0.1.m10 | M10 | 
 | [0.1.164](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.164) | 0.1.m12 | M12 0.12.200 | 
-| [0.1.165](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.165) | 0.1.m12.213 | M12 0.12.213|  
+| [0.1.165](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.165) | 0.1.m12.213 | M12 0.12.213| 
 | [0.1.175](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.175) | 0.1.m13 | M13 0.13.1513 | 
-| [0.1.177](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.177) | 0.1.m13 | M14 0.14.449 | 
-| [0.1.180](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1-SNAPSHOT) | master | Kotlin 1.0.0-beta-1038 |
+| [0.1.178](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.178) | 0.1.m14 | M14 0.14.449 |
+| [0.1.182](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.182) | - | Beta 1 1.0.0-beta-1103 | 
+| [0.1.186](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.186) | - | Beta 3 1.0.0-beta-3595 | 
+| [0.1.188](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1.188) | - | Beta 4 1.0.0-beta-4584 | 
+| [0.1-SNAPSHOT](http://repository.jetbrains.com/simple/spek/org/jetbrains/spek/spek/0.1-SNAPSHOT) | master | Kotlin 0.1-SNAPSHOT |
 
 ### Maven and Gradle
 


### PR DESCRIPTION
Hi, i found that version on download page outdated, so i add historical versions (one spek version per kotlin version) and current spek version. 