### PR TITLE
Removed superfluous code bits

### DIFF
--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Actions.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Actions.kt
@@ -1,23 +1,23 @@
 package org.jetbrains.spek.api
 
 
-public interface TestSpekAction {
-    public fun description(): String
-    public fun iterateGiven(it:(TestGivenAction) -> Unit)
+interface TestSpekAction {
+    fun description(): String
+    fun iterateGiven(it:(TestGivenAction) -> Unit)
 }
 
-public interface TestGivenAction {
-    public fun description(): String
-    public fun iterateOn(it: (TestOnAction) -> Unit)
+interface TestGivenAction {
+    fun description(): String
+    fun iterateOn(it: (TestOnAction) -> Unit)
 }
 
-public interface TestOnAction {
-    public fun description(): String
-    public fun iterateIt(it : (TestItAction) -> Unit)
+interface TestOnAction {
+    fun description(): String
+    fun iterateIt(it : (TestItAction) -> Unit)
 }
 
-public interface TestItAction {
-    public fun description(): String
-    public fun run()
+interface TestItAction {
+    fun description(): String
+    fun run()
 }
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Annotations.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Annotations.kt
@@ -1,3 +1,3 @@
 package org.jetbrains.spek.api
 
-public annotation class ignored(val why : String = "")
+annotation class ignored(val why : String = "")

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Assertions.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Assertions.kt
@@ -2,31 +2,31 @@ package org.jetbrains.spek.api
 
 import kotlin.test.*
 
-public fun <T> It.shouldEqual(expected: T, actual: T) : Unit {
+fun <T> It.shouldEqual(expected: T, actual: T) : Unit {
     assertEquals(expected, actual)
 }
 
-public fun <T> It.shouldNotEqual(expected: T, actual: T) : Unit {
+fun <T> It.shouldNotEqual(expected: T, actual: T) : Unit {
     assertFalse(null) { expected == actual }
 }
 
-public fun <T> It.shouldBeNull(actual: T?) : Unit {
+fun <T> It.shouldBeNull(actual: T?) : Unit {
     assertNull(actual)
 }
 
-public fun <T> It.shouldNotBeNull(actual: T?) : Unit {
+fun <T> It.shouldNotBeNull(actual: T?) : Unit {
     assertNotNull(actual as Any, "")
 }
 
-public fun <T> It.shouldBeTrue(actual: T) : Unit {
+fun <T> It.shouldBeTrue(actual: T) : Unit {
     assertTrue(actual == true)
 }
 
-public fun <T> It.shouldBeFalse(actual: T) : Unit {
+fun <T> It.shouldBeFalse(actual: T) : Unit {
     assertTrue(actual == false)
 }
 
-public fun <T: Throwable> It.shouldThrow(exceptionClass: Class<T>, block: () -> Unit): T {
+fun <T: Throwable> It.shouldThrow(exceptionClass: Class<T>, block: () -> Unit): T {
     return assertFailsWith(exceptionClass, block)
 }
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Exceptions.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Exceptions.kt
@@ -1,5 +1,5 @@
 package org.jetbrains.spek.api
 
-public class SkippedException(message: String): RuntimeException(message)
+class SkippedException(message: String): RuntimeException(message)
 
-public class PendingException(message: String): RuntimeException(message)
+class PendingException(message: String): RuntimeException(message)

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Given.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Given.kt
@@ -9,7 +9,7 @@ open class GivenImpl: org.jetbrains.spek.api.Given {
     private val beforeActions = linkedListOf<()->Unit>()
     private val afterActions = linkedListOf<()->Unit>()
 
-    public fun iterateOn(callback : (org.jetbrains.spek.api.TestOnAction) -> Unit) {
+    fun iterateOn(callback : (org.jetbrains.spek.api.TestOnAction) -> Unit) {
         org.jetbrains.spek.api.removingIterator(recordedActions) {
             // This doesn't actually work. Tests pass but tests are wrong
             beforeActions.forEach { it() }
@@ -22,11 +22,11 @@ open class GivenImpl: org.jetbrains.spek.api.Given {
     }
 
 
-    public override fun on(description: String, onExpression: org.jetbrains.spek.api.On.() -> Unit) {
+    override fun on(description: String, onExpression: org.jetbrains.spek.api.On.() -> Unit) {
         recordedActions.add(
                 object : org.jetbrains.spek.api.TestOnAction {
-                    public override fun description() = "on " + description
-                    public override fun iterateIt(it: (org.jetbrains.spek.api.TestItAction) -> Unit) {
+                    override fun description() = "on " + description
+                    override fun iterateIt(it: (org.jetbrains.spek.api.TestItAction) -> Unit) {
                         val on = org.jetbrains.spek.api.OnImpl()
                         on.onExpression()
                         return on.iterateIt(it)

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Incomplete.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Incomplete.kt
@@ -1,11 +1,11 @@
 package org.jetbrains.spek.api
 
-public fun Specification.given(description: String): Unit = given(description) { pending("Not implemented.") }
-public fun Given.on(description: String): Unit = on(description) { pending("Not implemented.") }
-public fun On.it(description: String): Unit = it(description) { pending("Not implemented.") }
+fun Specification.given(description: String): Unit = given(description) { pending("Not implemented.") }
+fun Given.on(description: String): Unit = on(description) { pending("Not implemented.") }
+fun On.it(description: String): Unit = it(description) { pending("Not implemented.") }
 
-public fun pending(message : String) : Unit = throw PendingException(message)
-public fun skip(message : String) : Unit = throw SkippedException(message)
+fun pending(message : String) : Unit = throw PendingException(message)
+fun skip(message : String) : Unit = throw SkippedException(message)
 
 
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/On.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/On.kt
@@ -5,15 +5,15 @@ import kotlin.collections.linkedListOf
 open class OnImpl: On {
     private val recordedActions = linkedListOf<TestItAction>()
 
-    public fun iterateIt(it : (TestItAction) -> Unit) {
+    fun iterateIt(it : (TestItAction) -> Unit) {
         removingIterator(recordedActions, it)
     }
 
-    public override fun it(description: String, itExpression: It.()->Unit) {
+    override fun it(description: String, itExpression: It.()->Unit) {
         recordedActions.add(
                 object : TestItAction {
-                    public override fun description() = "it " + description
-                    public override fun run() {
+                    override fun description() = "it " + description
+                    override fun run() {
                         ItImpl().itExpression()
                     }
                 })

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Spek.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Spek.kt
@@ -5,17 +5,17 @@ import org.junit.runner.*
 import kotlin.collections.linkedListOf
 
 @RunWith(JUnitClassRunner::class)
-public abstract class Spek : org.jetbrains.spek.api.Specification {
+abstract class Spek : Specification {
 
-    private val recordedActions = linkedListOf<org.jetbrains.spek.api.TestGivenAction>()
+    private val recordedActions = linkedListOf<TestGivenAction>()
 
-    public override fun given(description: String, givenExpression: org.jetbrains.spek.api.Given.() -> Unit) {
+    override fun given(description: String, givenExpression: Given.() -> Unit) {
         recordedActions.add(
-                object : org.jetbrains.spek.api.TestGivenAction {
-                    public override fun description() = "given " + description
+                object : TestGivenAction {
+                    override fun description() = "given " + description
 
-                    public override fun iterateOn(it: (org.jetbrains.spek.api.TestOnAction) -> Unit) {
-                        val given = org.jetbrains.spek.api.GivenImpl()
+                    override fun iterateOn(it: (TestOnAction) -> Unit) {
+                        val given = GivenImpl()
                         given.givenExpression()
                         given.iterateOn(it)
                     }
@@ -23,13 +23,13 @@ public abstract class Spek : org.jetbrains.spek.api.Specification {
 
     }
 
-    public fun iterateGiven(it: (org.jetbrains.spek.api.TestGivenAction) -> Unit): Unit = org.jetbrains.spek.api.removingIterator(recordedActions, it)
+    fun iterateGiven(it: (TestGivenAction) -> Unit): Unit = removingIterator(recordedActions, it)
 
-    public fun allGiven(): List<org.jetbrains.spek.api.TestGivenAction> = recordedActions
+    fun allGiven(): List<TestGivenAction> = recordedActions
 }
 
 
-public fun <T> Spek.givenData(data: Iterable<T>, givenExpression: org.jetbrains.spek.api.Given.(T) -> Unit) {
+fun <T> Spek.givenData(data: Iterable<T>, givenExpression: Given.(T) -> Unit) {
     for (entry in data) {
         given(entry.toString()) {
             givenExpression(entry)

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Structure.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Structure.kt
@@ -1,16 +1,16 @@
 package org.jetbrains.spek.api
 
-public interface Specification {
-    public fun given(description: String, givenExpression: Given.() -> Unit)
+interface Specification {
+    fun given(description: String, givenExpression: Given.() -> Unit)
 }
 
-public interface Given {
-    public fun on(description: String, onExpression: On.() -> Unit)
+interface Given {
+    fun on(description: String, onExpression: On.() -> Unit)
 }
 
-public interface On {
-    public fun it(description: String, itExpression: It.() -> Unit)
+interface On {
+    fun it(description: String, itExpression: It.() -> Unit)
 }
 
-public interface It {}
+interface It {}
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/ActionStatusReporter.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/ActionStatusReporter.kt
@@ -2,20 +2,20 @@ package org.jetbrains.spek.console
 
 import org.jetbrains.spek.api.*
 
-public interface ActionStatusReporter {
-    public fun started() {
+interface ActionStatusReporter {
+    fun started() {
     }
-    public fun completed() {
+    fun completed() {
     }
-    public fun skipped(why: String) {
+    fun skipped(why: String) {
     }
-    public fun pending(why: String) {
+    fun pending(why: String) {
     }
-    public fun failed(error: Throwable) {
+    fun failed(error: Throwable) {
     }
 }
 
-public class CompositeActionStatusReporter(val reporters: List<ActionStatusReporter>) : ActionStatusReporter {
+class CompositeActionStatusReporter(val reporters: List<ActionStatusReporter>) : ActionStatusReporter {
     override fun started() {
         for (reporter in reporters)
             reporter.started()
@@ -38,7 +38,7 @@ public class CompositeActionStatusReporter(val reporters: List<ActionStatusRepor
     }
 }
 
-public fun <T> executeWithReporting(t: T, reporter: ActionStatusReporter, action: T.() -> Unit) {
+fun <T> executeWithReporting(t: T, reporter: ActionStatusReporter, action: T.() -> Unit) {
     reporter.started()
     try {
         t.action()

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/ConsoleRunner.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/ConsoleRunner.kt
@@ -5,7 +5,7 @@ import kotlin.collections.toList
 import kotlin.text.split
 
 
-public fun main(args: Array<String>)  {
+fun main(args: Array<String>)  {
     if (args.size < 2) {
         printUsage()
     } else {
@@ -25,7 +25,7 @@ public fun main(args: Array<String>)  {
     System.exit(0)
 }
 
-public fun getOptions(args: Array<String>): Options {
+fun getOptions(args: Array<String>): Options {
     var index = 2
     var format = "text"
     var filename = ""

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/FileClassLoader.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/FileClassLoader.kt
@@ -12,7 +12,7 @@ import kotlin.collections.toTypedArray
 import kotlin.text.*
 
 
-public fun getUrlsForPaths(paths: List<String>): List<URL> {
+fun getUrlsForPaths(paths: List<String>): List<URL> {
     val urls = arrayListOf<URL>()
     paths.forEach {
         val file = File(it)
@@ -25,13 +25,13 @@ public fun getUrlsForPaths(paths: List<String>): List<URL> {
 }
 
 
-public fun findClassesInClassPath(packageName: String): List<String> {
+fun findClassesInClassPath(packageName: String): List<String> {
     val classLoader = Thread.currentThread().getContextClassLoader()
     val packageUrl = classLoader?.getResource(packageName.replace('.', '/'))
     return findClassesInUrls(listOf(packageUrl!!), packageName)
 }
 
-public fun findClassesInUrls(urls: List<URL>, packageName: String): List<String> {
+fun findClassesInUrls(urls: List<URL>, packageName: String): List<String> {
     val names = arrayListOf<String>()
     for (url in urls) {
         if (url.toString().endsWith(".jar")) {
@@ -62,7 +62,7 @@ public fun findClassesInUrls(urls: List<URL>, packageName: String): List<String>
     return names
 }
 
-public fun findSpecs(paths: List<String>, packageName: String): MutableList<TestSpekAction> {
+fun findSpecs(paths: List<String>, packageName: String): MutableList<TestSpekAction> {
     val result = arrayListOf<TestSpekAction>()
     val urls = getUrlsForPaths(paths)
     val classloader = URLClassLoader.newInstance(urls.toTypedArray())!!
@@ -85,7 +85,7 @@ private fun AnnotatedElement.checkSkipped() {
     if (skip != null) throw SkippedException(skip.why)
 }
 
-public data class ExtensionFunctionSpek(val method: Method) : TestSpekAction {
+data class ExtensionFunctionSpek(val method: Method) : TestSpekAction {
     override fun description(): String = method.toString()
 
     override fun iterateGiven(it: (TestGivenAction) -> Unit) {
@@ -100,7 +100,7 @@ public data class ExtensionFunctionSpek(val method: Method) : TestSpekAction {
     }
 }
 
-public data class ClassSpek<T : Spek>(val specificationClass: Class<out T>) : TestSpekAction {
+data class ClassSpek<T : Spek>(val specificationClass: Class<out T>) : TestSpekAction {
     override fun description(): String = specificationClass.getName()
 
     override fun iterateGiven(it: (TestGivenAction) -> Unit) {

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/HTMLWorkflowReporter.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/HTMLWorkflowReporter.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.spek.console
 
-public class HtmlWorkflowReporter(val suite: String, val device: OutputDevice, val cssFile: String) : WorkflowReporter {
+class HtmlWorkflowReporter(val suite: String, val device: OutputDevice, val cssFile: String) : WorkflowReporter {
     //TODO: could use markdown + js
     var css = ""
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/Options.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/Options.kt
@@ -1,8 +1,8 @@
 package org.jetbrains.spek.console
 
-public data class Options(
-        public val paths: List<String>,
-        public val packageName: String,
-        public val format: String,
-        public val filename: String,
-        public val cssFile: String)
+data class Options(
+        val paths: List<String>,
+        val packageName: String,
+        val format: String,
+        val filename: String,
+        val cssFile: String)

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/OutputDeviceWorkflowReporter.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/OutputDeviceWorkflowReporter.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.spek.console
 
-public class OutputDeviceWorkflowReporter(val device: OutputDevice) : WorkflowReporter {
+class OutputDeviceWorkflowReporter(val device: OutputDevice) : WorkflowReporter {
     override fun spek(spek: String): ActionStatusReporter {
         return object : ActionStatusReporter {
             override fun started() {

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/OutputDevices.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/OutputDevices.kt
@@ -2,14 +2,14 @@ package org.jetbrains.spek.console
 
 import java.io.*
 
-public interface OutputDevice {
-    public fun output(message: String)
+interface OutputDevice {
+    fun output(message: String)
 }
 
-public class FileOutputDevice(filename: String) : OutputDevice, Closeable {
+class FileOutputDevice(filename: String) : OutputDevice, Closeable {
     val writer = BufferedWriter(PrintWriter(File(filename)))
 
-    public override fun close() {
+    override fun close() {
         writer.close()
     }
 
@@ -20,7 +20,7 @@ public class FileOutputDevice(filename: String) : OutputDevice, Closeable {
     }
 }
 
-public class ConsoleOutputDevice : OutputDevice {
+class ConsoleOutputDevice : OutputDevice {
     override fun output(message: String) {
         println(message)
     }

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/Runner.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/Runner.kt
@@ -4,8 +4,8 @@ import org.jetbrains.spek.api.*
 import kotlin.collections.forEach
 
 
-public class Runner(val listener: WorkflowReporter) {
-    public fun runSpecs(paths: List<String> , packageName: String) {
+class Runner(val listener: WorkflowReporter) {
+    fun runSpecs(paths: List<String> , packageName: String) {
         run(findSpecs(paths, packageName))
     }
 
@@ -16,7 +16,7 @@ public class Runner(val listener: WorkflowReporter) {
     }
 }
 
-public fun executeSpek(specificationClass: TestSpekAction, listener: WorkflowReporter) {
+fun executeSpek(specificationClass: TestSpekAction, listener: WorkflowReporter) {
     val spekDescription = specificationClass.description()
     executeWithReporting(specificationClass, listener.spek(spekDescription)) {
         iterateGiven { given ->

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/console/WorkflowReporter.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/console/WorkflowReporter.kt
@@ -3,18 +3,18 @@ package org.jetbrains.spek.console
 import kotlin.collections.arrayListOf
 import kotlin.collections.map
 
-public interface WorkflowReporter {
-    public fun spek(spek: String): ActionStatusReporter
-    public fun given(spek: String, given: String): ActionStatusReporter
-    public fun on(spek: String, given: String, on: String): ActionStatusReporter
-    public fun it(spek: String, given: String, on: String, it: String): ActionStatusReporter
+interface WorkflowReporter {
+    fun spek(spek: String): ActionStatusReporter
+    fun given(spek: String, given: String): ActionStatusReporter
+    fun on(spek: String, given: String, on: String): ActionStatusReporter
+    fun it(spek: String, given: String, on: String, it: String): ActionStatusReporter
 }
 
 
-public class CompositeWorkflowReporter : WorkflowReporter {
+class CompositeWorkflowReporter : WorkflowReporter {
     private val listeners = arrayListOf<WorkflowReporter>()
 
-    public fun addListener(l: WorkflowReporter) {
+    fun addListener(l: WorkflowReporter) {
         listeners.add(l)
     }
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/junit/JUnitClassRunner.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/junit/JUnitClassRunner.kt
@@ -17,7 +17,7 @@ data class JUnitUniqueId(val id: Int) : Serializable {
     }
 }
 
-public fun junitAction(description: Description, notifier: RunNotifier, action: () -> Unit) {
+fun junitAction(description: Description, notifier: RunNotifier, action: () -> Unit) {
     if (description.isTest) notifier.fireTestStarted(description)
     try {
         action()
@@ -32,7 +32,7 @@ public fun junitAction(description: Description, notifier: RunNotifier, action: 
     }
 }
 
-public class JUnitOnRunner<T>(val specificationClass: Class<T>, val given: TestGivenAction, val on: TestOnAction) : ParentRunner<TestItAction>(specificationClass) {
+class JUnitOnRunner<T>(val specificationClass: Class<T>, val given: TestGivenAction, val on: TestOnAction) : ParentRunner<TestItAction>(specificationClass) {
 
     val _children by lazy(LazyThreadSafetyMode.NONE) {
         val result = arrayListOf<TestItAction>()
@@ -70,7 +70,7 @@ public class JUnitOnRunner<T>(val specificationClass: Class<T>, val given: TestG
     }
 }
 
-public class JUnitGivenRunner<T>(val specificationClass: Class<T>, val given: TestGivenAction) : ParentRunner<JUnitOnRunner<T>>(specificationClass) {
+class JUnitGivenRunner<T>(val specificationClass: Class<T>, val given: TestGivenAction) : ParentRunner<JUnitOnRunner<T>>(specificationClass) {
 
     val _children by lazy(LazyThreadSafetyMode.NONE) {
         val result = arrayListOf<JUnitOnRunner<T>>()
@@ -104,7 +104,7 @@ public class JUnitGivenRunner<T>(val specificationClass: Class<T>, val given: Te
     }
 }
 
-public class JUnitClassRunner<T>(val specificationClass: Class<T>) : ParentRunner<JUnitGivenRunner<T>>(specificationClass) {
+class JUnitClassRunner<T>(val specificationClass: Class<T>) : ParentRunner<JUnitGivenRunner<T>>(specificationClass) {
     private val suiteDescription = Description.createSuiteDescription(specificationClass)
 
     override fun getChildren(): MutableList<JUnitGivenRunner<T>> = _children

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleIncUtilConsoleTest.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleIncUtilConsoleTest.kt
@@ -2,7 +2,7 @@ package org.jetbrains.spek.samples
 
 import org.jetbrains.spek.api.*
 
-public class IncUtilConsoleSpecs: Spek() {
+class IncUtilConsoleSpecs: Spek() {
     init {
     given("an inc util") {
 

--- a/spek-samples/src/test/kotlin/RunSamplesInJUnitTest.kt
+++ b/spek-samples/src/test/kotlin/RunSamplesInJUnitTest.kt
@@ -8,7 +8,7 @@ import org.junit.internal.TextListener
 import org.jetbrains.spek.console.main
 
 
-public class RunSamplesInJUnitTest {
+class RunSamplesInJUnitTest {
     @test fun try_junit() {
         with(JUnitCore()) {
             addListener(TextListener(RealSystem()))

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/api/IntegrationTestCase.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/api/IntegrationTestCase.kt
@@ -9,7 +9,7 @@ import kotlin.text.split
 import kotlin.text.toRegex
 import kotlin.text.trim
 
-public open class IntegrationTestCase {
+open class IntegrationTestCase {
 
     fun runTest(case: TestSpekAction, vararg expected: String) {
         val list = arrayListOf<String>()
@@ -31,17 +31,17 @@ public open class IntegrationTestCase {
                 )
     }
 
-    public fun data(f: Specification.() -> Unit) : TestSpekAction {
+    fun data(f: Specification.() -> Unit) : TestSpekAction {
         val d = object : Data() {}
         d.f()
         return d
     }
 
-    public abstract class Data : Spek(), TestSpekAction {
+    abstract class Data : Spek(), TestSpekAction {
         override fun description(): String = "42"
     }
 
-    public class TestLogger(val output: MutableList<String>): WorkflowReporter {
+    class TestLogger(val output: MutableList<String>): WorkflowReporter {
         private fun step(prefix:String) : ActionStatusReporter = object : ActionStatusReporter {
             override fun started() {
                 output.add(prefix + " START")

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/api/ListenerTest.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/api/ListenerTest.kt
@@ -8,7 +8,7 @@ import org.jetbrains.spek.console.ActionStatusReporter
 import org.jetbrains.spek.console.WorkflowReporter
 import org.jetbrains.spek.console.CompositeWorkflowReporter
 
-public class ListenerTest {
+class ListenerTest {
     val firstStepListener = Mockito.mock(ActionStatusReporter::class.java)
     val firstListener = Mockito.mock(WorkflowReporter::class.java)!!
 

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/api/SampleTests.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/api/SampleTests.kt
@@ -2,7 +2,7 @@ package org.jetbrains.spek.api
 
 import org.junit.Test as test
 
-public class SampleCalculatorIntegrationTest : IntegrationTestCase() {
+class SampleCalculatorIntegrationTest : IntegrationTestCase() {
     @test fun inc() = runTest(data{
         class SampleIncUtil {
             fun incValueBy(value: Int, inc: Int) = value + inc

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/api/SkipTest.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/api/SkipTest.kt
@@ -2,7 +2,7 @@ package org.jetbrains.spek.api
 
 import org.junit.Test as test
 
-public class SkipTest : IntegrationTestCase() {
+class SkipTest : IntegrationTestCase() {
     @test fun skipIt() =
             runTest(data {
                 given("a situation") {

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/api/UtilTest.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/api/UtilTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.*
 import org.jetbrains.spek.console.ActionStatusReporter
 import org.jetbrains.spek.console.executeWithReporting
 
-public class UtilTest {
+class UtilTest {
     val listener = Mockito.mock(ActionStatusReporter::class.java)!!
     val action = Mockito.mock(ActionStatusReporter::class.java)!!
 

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/console/APITest.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/console/APITest.kt
@@ -4,7 +4,7 @@ import org.junit.Test as test
 import kotlin.test.assertEquals
 import org.jetbrains.spek.api.Spek
 
-public class APITest {
+class APITest {
     @test fun allGivens() {
         //given a spek
         val spek = object : Spek() {}

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/console/ConsoleRunnerTest.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/console/ConsoleRunnerTest.kt
@@ -4,7 +4,7 @@ import kotlin.collections.listOf
 import org.junit.Test as test
 import kotlin.test.assertEquals
 
-public class ConsoleRunnerTest {
+class ConsoleRunnerTest {
     @test fun getEmptyOptions() {
         //given an empty array
         //when we call getOptions

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/console/HTMLListenerTest.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/console/HTMLListenerTest.kt
@@ -3,7 +3,7 @@ package org.jetbrains.spek.console
 import org.junit.Test as test
 import kotlin.test.assertTrue
 
-public class HTMLListenerTest {
+class HTMLListenerTest {
     @test fun todo() {
         assertTrue(true, "todo")
     }

--- a/spek-tests/src/test/kotlin/org/jetbrains/spek/console/PlainTextListenerTest.kt
+++ b/spek-tests/src/test/kotlin/org/jetbrains/spek/console/PlainTextListenerTest.kt
@@ -3,7 +3,7 @@ package org.jetbrains.spek.console
 import org.mockito.Mockito
 import org.junit.Test as test
 
-public class TextListenerTest {
+class TextListenerTest {
     val device = Mockito.mock(OutputDevice::class.java)!!
     val textListener = OutputDeviceWorkflowReporter(device)
 


### PR DESCRIPTION
Removed all the qualified names in api.Spek, since they share the same
package and make it a lot harder to read.
Removed all the "public" modifiers, since they just cluttered the code
and were inconsistent.