### PR TITLE
Fixed a couple of wrong groupIds

### DIFF
--- a/download.md
+++ b/download.md
@@ -33,7 +33,7 @@ To use it in Maven insert the following in your pom.xml file:
 {% highlight xml %}
  
  <dependency>
-    <groupId>org.spek</groupId>
+    <groupId>org.jetbrains.spek</groupId>
     <artifactId>spek</artifactId>
     <version>$version</version>
     <type>pom</type>
@@ -61,7 +61,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'org.spek:spek:$version'
+    testCompile 'org.jetbrains.spek:spek:$version'
 }
 
 {% endhighlight %}


### PR DESCRIPTION
Download page have a couple of groupId `org.spek` that should be `org.jetbrains.spek`.