### PR TITLE
spek-41 init keyword is clunky

### DIFF
--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/Spek.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/Spek.kt
@@ -6,6 +6,9 @@ import java.util.*
 
 @RunWith(JUnitClassRunner::class)
 abstract class Spek : Specification {
+    constructor(body: Spek.() -> Unit = {}) {
+        this.body()
+    }
 
     private val recordedActions = LinkedList<TestGivenAction>()
 

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleCalculatorConsoleTest.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/SampleCalculatorConsoleTest.kt
@@ -1,25 +1,22 @@
 package org.jetbrains.spek.samples
 
 import org.jetbrains.spek.api.*
-import org.jetbrains.spek.samples.SampleCalculator
 
-    class CalculatorConsoleSpecs : Spek() {
-        init {
-            given("a calculator") {
-                val calculator = SampleCalculator()
-                on("calling sum with two numbers") {
-                    val sum = calculator.sum(2, 4)
-                    it("should return the result of adding the first number to the second number") {
-                        shouldEqual(6, sum)
-                    }
-                }
-                on("calling subtract with two numbers") {
-                    val subtract = calculator.subtract(4, 2)
-                    it("should return the result of subtracting the second number from the first number") {
-                        shouldEqual(2, subtract)
-                    }
-                }
+class CalculatorConsoleSpecs : Spek({
+    given("a calculator") {
+        val calculator = SampleCalculator()
+        on("calling sum with two numbers") {
+            val sum = calculator.sum(2, 4)
+            it("should return the result of adding the first number to the second number") {
+                shouldEqual(6, sum)
+            }
+        }
+        on("calling subtract with two numbers") {
+            val subtract = calculator.subtract(4, 2)
+            it("should return the result of subtracting the second number from the first number") {
+                shouldEqual(2, subtract)
             }
         }
     }
+})
 


### PR DESCRIPTION
I added constructor to the ``Spek`` class with optional parameter that allow to create tests with the following syntax:
```
class SomeTest: Spek({
    give("...") {
        ...
    }
})
```
This parameter is optional so the backward compatibility is stored