### PR TITLE
Enables resource autoCleanup

### DIFF
--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/AssertionBody.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/AssertionBody.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.spek.api
+
+import java.io.Closeable
+
+interface AssertionBody {
+
+    fun onCleanup(block: () -> Unit)
+
+    fun <T : Closeable?> T.autoCleanup(): T = apply { if (this != null) onCleanup { close() } }
+
+// When JDK 7 is officially supported:
+//    fun <T : AutoCloseable?> T.autoCleanup(): T = apply { if (this != null) onCleanup { close() } }
+
+}

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/DescribeBody.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/DescribeBody.kt
@@ -5,11 +5,11 @@ interface DescribeBody  {
     fun xdescribe(description: String, evaluateBody: DescribeBody.() -> Unit)
     fun fdescribe(description: String, evaluateBody: DescribeBody.() -> Unit)
 
-    fun it(description: String, assertions: () -> Unit)
-    fun xit(description: String, assertions: () -> Unit)
-    fun fit(description: String, assertions: () -> Unit)
+    fun it(description: String, assertions: AssertionBody.() -> Unit)
+    fun xit(description: String, assertions: AssertionBody.() -> Unit)
+    fun fit(description: String, assertions: AssertionBody.() -> Unit)
 
-    fun beforeEach(actions: () -> Unit)
+    fun beforeEach(actions: AssertionBody.() -> Unit)
     fun afterEach(actions: () -> Unit)
 
     fun on(description: String, evaluateBody: DescribeBody.() -> Unit) = describe(description, evaluateBody)

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/DescribeParser.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/DescribeParser.kt
@@ -3,7 +3,7 @@ package org.jetbrains.spek.api
 import java.util.*
 
 class DescribeParser() : DescribeBody {
-    val befores: LinkedList<() -> Unit> = LinkedList()
+    val befores: LinkedList<AssertionBody.() -> Unit> = LinkedList()
     val afters: LinkedList<() -> Unit> = LinkedList()
     val children = LinkedList<SpekTree>()
 
@@ -36,7 +36,7 @@ class DescribeParser() : DescribeBody {
                 listOf()))
     }
 
-    override fun xit(description: String, @Suppress("UNUSED_PARAMETER") assertions: () -> Unit) {
+    override fun xit(description: String, @Suppress("UNUSED_PARAMETER") assertions: AssertionBody.() -> Unit) {
         children.add(SpekTree(
                 "it " + description,
                 ActionType.IT,
@@ -44,7 +44,7 @@ class DescribeParser() : DescribeBody {
                 listOf()))
     }
 
-    override fun it(description: String, assertions: () -> Unit) {
+    override fun it(description: String, assertions: AssertionBody.() -> Unit) {
         children.add(SpekTree(
                 "it " + description,
                 ActionType.IT,
@@ -66,7 +66,7 @@ class DescribeParser() : DescribeBody {
         ))
     }
 
-    override fun fit(description: String, assertions: () -> Unit) {
+    override fun fit(description: String, assertions: AssertionBody.() -> Unit) {
         children.add(SpekTree(
                 "it " + description,
                 ActionType.IT,
@@ -77,7 +77,7 @@ class DescribeParser() : DescribeBody {
     }
 
 
-    override fun beforeEach(actions: () -> Unit) {
+    override fun beforeEach(actions: AssertionBody.() -> Unit) {
         befores.add(actions)
     }
 

--- a/spek-core/src/main/kotlin/org/jetbrains/spek/api/SpekNodeRunner.kt
+++ b/spek-core/src/main/kotlin/org/jetbrains/spek/api/SpekNodeRunner.kt
@@ -5,23 +5,55 @@ interface SpekNodeRunner {
     fun run(tree: SpekTree, notifier: Notifier, innerAction: () -> Unit)
 }
 
-class SpekStepRunner(val befores: LinkedList<() -> Unit> = LinkedList(),
+class SpekAssertionBody : AssertionBody {
+    val cleanups = ArrayList<() -> Unit>()
+    override fun onCleanup(block: () -> Unit) { cleanups += block }
+}
+
+class SpekStepRunner(val befores: LinkedList<AssertionBody.() -> Unit> = LinkedList(),
                      val afters: LinkedList<() -> Unit> = LinkedList(),
-                     val assertions: () -> Unit = {}): SpekNodeRunner {
+                     val assertions: AssertionBody.() -> Unit = {}): SpekNodeRunner {
 
     override fun run(tree: SpekTree, notifier: Notifier, innerAction: () -> Unit) {
         notifier.start(tree)
         try {
-            befores.forEach { it() }
-            assertions()
-            innerAction()
-            afters.forEach { it() }
+            val body = SpekAssertionBody()
+            try {
+                befores.forEach { body.it() }
+                body.assertions()
+                innerAction()
+            } catch(e: Throwable) {
+                cleanup(afters + body.cleanups, e)
+                throw e
+            }
+            cleanup(afters + body.cleanups)
             notifier.succeed(tree)
         } catch(e: Throwable) {
             notifier.fail(tree, e)
         }
     }
 
+    private fun cleanup(blocks: List<() -> Unit>, bodyException: Throwable? = null) {
+        var exception: Exception? = null
+        for (block in blocks) {
+            try {
+                block.invoke()
+            } catch (e: Exception) {
+                if (bodyException != null) {
+// When JDK 7 is officially supported:
+//                    bodyException.addSuppressed(e)
+                } else if (exception == null) {
+                    exception = e
+                } else {
+// When JDK 7 is officially supported:
+//                    exception.addSuppressed(e)
+                }
+            }
+        }
+        if (exception != null) {
+            throw exception
+        }
+    }
 
 }
 

--- a/spek-core/src/test/kotlin/org/jetbrains/spek/api/integration/ExceptionHandlingTest.kt
+++ b/spek-core/src/test/kotlin/org/jetbrains/spek/api/integration/ExceptionHandlingTest.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.spek.api.integration
 
+import kotlin.test.assertTrue
 import org.junit.Test as test
 
 class ExceptionHandlingTest : IntegrationTestCase() {
@@ -43,4 +44,29 @@ class ExceptionHandlingTest : IntegrationTestCase() {
         it should fail: FAIL: error occurred
         something: FINISH
         Spek: FINISH""")
+
+    @test fun cleanupOnException() = runTest(data{
+        given("something") {
+            val closeable = CloseableTest()
+            it("should fail") {
+                closeable.autoCleanup()
+                throw RuntimeException("error occurred")
+            }
+            it("should have clean up") {
+                assertTrue(closeable.closed)
+            }
+        }
+    }, """Spek: START
+        something: START
+        it should fail: START
+        it should fail: FAIL: error occurred
+        something: FINISH
+        Spek: FINISH
+        Spek: START
+        something: START
+        it should have clean up: START
+        it should have clean up: FINISH
+        something: FINISH
+        Spek: FINISH
+        """)
 }

--- a/spek-core/src/test/kotlin/org/jetbrains/spek/api/integration/IntegrationTestCase.kt
+++ b/spek-core/src/test/kotlin/org/jetbrains/spek/api/integration/IntegrationTestCase.kt
@@ -6,8 +6,14 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.SpekTree
 import org.jetbrains.spek.console.executeSpek
 import org.junit.Assert
+import java.io.Closeable
 
 open class IntegrationTestCase {
+
+    class CloseableTest : Closeable {
+        var closed = false
+        override fun close() { closed = true }
+    }
 
     fun runTest(case: Spek, vararg expected: String) {
         val list = arrayListOf<String>()

--- a/spek-core/src/test/kotlin/org/jetbrains/spek/api/integration/SampleCalculatorIntegrationTest.kt
+++ b/spek-core/src/test/kotlin/org/jetbrains/spek/api/integration/SampleCalculatorIntegrationTest.kt
@@ -1,9 +1,11 @@
 package org.jetbrains.spek.api.integration
 
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.junit.Test as test
 
 class SampleCalculatorIntegrationTest : IntegrationTestCase() {
+
     @test fun inc() = runTest(data{
         class SampleIncUtil {
             fun incValueBy(value: Int, inc: Int) = value + inc
@@ -13,8 +15,13 @@ class SampleCalculatorIntegrationTest : IntegrationTestCase() {
             val incUtil = SampleIncUtil()
             on("calling incValueBy with 4 and given number 6") {
                 val result = incUtil.incValueBy(4, 6)
+                val closeable = CloseableTest()
                 it("should return 10") {
+                    closeable.autoCleanup()
                     assertEquals(result, 10)
+                }
+                it("should have clean up") {
+                    assertTrue(closeable.closed)
                 }
             }
         }
@@ -23,6 +30,14 @@ class SampleCalculatorIntegrationTest : IntegrationTestCase() {
         calling incValueBy with 4 and given number 6: START
         it should return 10: START
         it should return 10: FINISH
+        calling incValueBy with 4 and given number 6: FINISH
+        an inc util: FINISH
+        Spek: FINISH
+        Spek: START
+        an inc util: START
+        calling incValueBy with 4 and given number 6: START
+        it should have clean up: START
+        it should have clean up: FINISH
         calling incValueBy with 4 and given number 6: FINISH
         an inc util: FINISH
         Spek: FINISH""")

--- a/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/ResourceTest.kt
+++ b/spek-samples/src/main/kotlin/org/jetbrains/spek/samples/ResourceTest.kt
@@ -1,0 +1,28 @@
+package org.jetbrains.spek.samples
+
+import org.jetbrains.spek.api.Spek
+import java.io.ByteArrayOutputStream
+import kotlin.test.assertEquals
+
+class ResourceTest : Spek({
+
+    given("a closeable resource opened in a test") {
+
+        it("should be closed if the test succeeds") {
+            val baos = ByteArrayOutputStream()
+            baos.autoCleanup()
+
+            assertEquals(42, 42)
+        }
+
+        it("should be closed if the test fails") {
+            val baos = ByteArrayOutputStream()
+            baos.autoCleanup()
+
+            assertEquals(42, 21)
+        }
+
+    }
+
+})
+


### PR DESCRIPTION
This PR does 2 things:
- It makes sure that cleanup code (including `afterEach`) is called even if the test has failed
- It introduces a new idiom for post-run resource cleanup

### Cleanup code is called even if the test has failed

In the current implementation, the `afterEach` callbacks are called after the test **only if it succeeds**, which is, to me, a bug. So this PR corrects that.

### New idiom for post resource cleanup

first, a demo ;)

```kotlin
    it("should demonstrate autoCleanup") {
        val connection = setUpDatabase().autoCleanup()
        /* ... test the database ... */
    }
```

The important part here is the `autoCleanup` call.  
What it does is simple: it registers a callback that will be called once the test has finished, *whether or not it has succeeded* and, in that callback, close the connection.

`autoCleanup` is very usefull for `Closeable` objects, but for any other kind of cleanup, you can register your own callbacks:

```kotlin
    it("should demonstrate onCleanup") {
        val network = setUpNetwork()
        onCleanup {
            /* ... complicated cleanup ... */
        }
        /* ... test the network ... */
    }
```

Note that `beforeEach` callbacks are also able to register `onCleanup` callbacks and `autoCleanup` resources, which brings me to the...

### C-C-C-C-Combo!

To my opinion, this PR should deprecate `afterEach`. Let me explain.

Imagine a Spek class hierarchy. For example, we have a main class that sets up a database, beaucause all tests of the project will need it, and a sub-class for a test sub-set that will need a network connection.  
Now, each class registers its own resource on `beforeEach` and cleanup in `afterEach`:

```kotlin
    beforeEach {
        this.resource = openResource()
    }
    afterEach {
        this.resource.close()
    }
```

Feel free to replace `resource` by `database` or `network`. The issue is simple. There is no way to link resource opening to the resource cleanup. Because `afterEach` is called every time, this can cause trouble if one resource has been opened and the second throws an exception upon opening. Only one resource will be opened, but both closing code will be called, which can lead to unpleasant situations.  
To correct this, we have to check whether the resource was opened:

```kotlin
    beforeEach {
        val opened = true
        this.resource = openResource()
    }
    afterEach {
        if (opened)
            this.resource.close()
        opened = false
    }
```

Yikes.

What this PR introduces is, IMHO, better and easier:

```kotlin
    beforeEach {
        this.resource = openResource()
        onCleanup {
            this.resource.close()
        }
    }
```

Or better yet:

```kotlin
    beforeEach {
        this.resource = openResource().autoCleanup()
    }
```

This idiom makes sure that the `onCleanup` call is called *only if* the `beforeEach` callback was called, effectively linking the resource opening and cleanup.

That's why I think `afterEach` should be deprecated. It's better to link an `onCleanup` code to the success of a `beforeEach` than registering a `afterEach` that may be called "orphaned".