### PR TITLE
Enables resource autoCleanup for Junit5

### DIFF
--- a/spek-api/src/main/kotlin/org/jetbrains/spek/api/dsl/Dsl.kt
+++ b/spek-api/src/main/kotlin/org/jetbrains/spek/api/dsl/Dsl.kt
@@ -6,9 +6,9 @@ package org.jetbrains.spek.api.dsl
  */
 interface Dsl {
     fun group(description: String, pending: Pending = Pending.No, body: org.jetbrains.spek.api.dsl.Dsl.() -> Unit)
-    fun test(description: String, pending: Pending = Pending.No, body: () -> Unit)
+    fun test(description: String, pending: Pending = Pending.No, body: TestBody.() -> Unit)
 
-    fun beforeEach(callback: () -> Unit)
+    fun beforeEach(callback: TestBody.() -> Unit)
     fun afterEach(callback: () -> Unit)
 
     // fun <T: Spek> includeSpec(spec: KClass<T>)

--- a/spek-api/src/main/kotlin/org/jetbrains/spek/api/dsl/Standard.kt
+++ b/spek-api/src/main/kotlin/org/jetbrains/spek/api/dsl/Standard.kt
@@ -39,7 +39,7 @@ fun Dsl.given(description: String, body: Dsl.() -> Unit) {
  * @author Ranie Jade Ramiso
  * @since 1.0
  */
-fun Dsl.it(description: String, body: () -> Unit) {
+fun Dsl.it(description: String, body: TestBody.() -> Unit) {
     test("it $description", body = body)
 }
 
@@ -49,7 +49,7 @@ fun Dsl.it(description: String, body: () -> Unit) {
  * @author Ranie Jade Ramiso
  * @since 1.0
  */
-fun Dsl.on(description: String, body: () -> Unit) {
+fun Dsl.on(description: String, body: TestBody.() -> Unit) {
     test("on $description", body = body)
 }
 
@@ -89,7 +89,7 @@ fun Dsl.xgiven(description: String, reason: String? = null, body: Dsl.() -> Unit
  * @author Ranie Jade Ramiso
  * @since 1.0
  */
-fun Dsl.xit(description: String, reason: String? = null, body: () -> Unit = {}) {
+fun Dsl.xit(description: String, reason: String? = null, body: TestBody.() -> Unit = {}) {
     test("it $description", Pending.Yes(reason), body)
 }
 
@@ -99,7 +99,7 @@ fun Dsl.xit(description: String, reason: String? = null, body: () -> Unit = {}) 
  * @author Ranie Jade Ramiso
  * @since 1.0
  */
-fun Dsl.xon(description: String, reason: String? = null, body: () -> Unit = {}) {
+fun Dsl.xon(description: String, reason: String? = null, body: TestBody.() -> Unit = {}) {
     test("on $description", Pending.Yes(reason), body)
 }
 

--- a/spek-api/src/main/kotlin/org/jetbrains/spek/api/dsl/TestBody.kt
+++ b/spek-api/src/main/kotlin/org/jetbrains/spek/api/dsl/TestBody.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.spek.api.dsl
+
+import java.io.Closeable
+
+interface TestBody {
+    fun onCleanup(block: () -> Unit)
+
+    fun <T : Closeable?> T.autoCleanup(): T = apply { if (this != null) onCleanup { close() } }
+
+// When JDK 7 is officially supported:
+//    fun <T : AutoCloseable?> T.autoCleanup(): T = apply { if (this != null) onCleanup { close() } }
+}

--- a/spek-junit-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
+++ b/spek-junit-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
@@ -5,6 +5,7 @@ import org.jetbrains.spek.api.SubjectSpek
 import org.jetbrains.spek.api.dsl.Dsl
 import org.jetbrains.spek.api.dsl.Pending
 import org.jetbrains.spek.api.dsl.SubjectDsl
+import org.jetbrains.spek.api.dsl.TestBody
 import org.jetbrains.spek.api.memoized.CachingMode
 import org.jetbrains.spek.api.memoized.Subject
 import org.jetbrains.spek.engine.memoized.SubjectImpl
@@ -86,12 +87,12 @@ class SpekTestEngine: HierarchicalTestEngine<SpekExecutionContext>() {
             body.invoke(Collector(group))
         }
 
-        override fun test(description: String, pending: Pending, body: () -> Unit) {
+        override fun test(description: String, pending: Pending, body: TestBody.() -> Unit) {
             val test = Scope.Test(root.uniqueId.append(TEST_SEGMENT_TYPE, description), pending, body)
             root.addChild(test)
         }
 
-        override fun beforeEach(callback: () -> Unit) {
+        override fun beforeEach(callback: TestBody.() -> Unit) {
             root.fixtures.beforeEach.add(callback)
         }
 

--- a/spek-junit-engine/src/main/kotlin/org/jetbrains/spek/engine/scope/Fixtures.kt
+++ b/spek-junit-engine/src/main/kotlin/org/jetbrains/spek/engine/scope/Fixtures.kt
@@ -1,9 +1,10 @@
 package org.jetbrains.spek.engine.scope
 
+import org.jetbrains.spek.api.dsl.TestBody
 import java.util.*
 
 /**
  * @author Ranie Jade Ramiso
  */
-class Fixtures(var beforeEach: LinkedList<() -> Unit> = LinkedList(),
+class Fixtures(var beforeEach: LinkedList<TestBody.() -> Unit> = LinkedList(),
                var afterEach: LinkedList<() -> Unit> = LinkedList())

--- a/spek-junit-engine/src/test/kotlin/org/jetbrains/spek/engine/AfterEachTest.kt
+++ b/spek-junit-engine/src/test/kotlin/org/jetbrains/spek/engine/AfterEachTest.kt
@@ -12,6 +12,8 @@ import org.junit.gen5.api.Test
 class AfterEachTest: AbstractSpekTestEngineTest() {
     @Test
     fun testAfterEach() {
+        counter = 0
+
         class TestSpek: Spek({
             group("group") {
                 test("test") { }
@@ -40,6 +42,46 @@ class AfterEachTest: AbstractSpekTestEngineTest() {
         val recorder = executeTestsForClass(TestSpek::class)
 
         assertThat(recorder.testFailureCount, equalTo(2))
+    }
+
+    @Test
+    fun testBeforeEachFailure() {
+        counter = 0
+
+        class TestSpek: Spek({
+            group("group") {
+                beforeEach { assertThat(true, equalTo(false)) }
+                test("test") { }
+                test("another test") { }
+                afterEach { counter++ }
+            }
+
+        })
+
+        val recorder = executeTestsForClass(TestSpek::class)
+
+        assertThat(recorder.testFailureCount, equalTo(2))
+        assertThat(counter, equalTo(0))
+    }
+
+    @Test
+    fun testTestFailure() {
+        counter = 0
+
+        class TestSpek: Spek({
+            group("group") {
+                test("test") { }
+                test("another test") { }
+                test("failing test") { assertThat(true, equalTo(false)) }
+                afterEach { counter++ }
+            }
+
+        })
+
+        val recorder = executeTestsForClass(TestSpek::class)
+
+        assertThat(recorder.testFailureCount, equalTo(1))
+        assertThat(counter, equalTo(2))
     }
 
     companion object {

--- a/spek-junit-engine/src/test/kotlin/org/jetbrains/spek/engine/AfterEachTest.kt
+++ b/spek-junit-engine/src/test/kotlin/org/jetbrains/spek/engine/AfterEachTest.kt
@@ -61,7 +61,7 @@ class AfterEachTest: AbstractSpekTestEngineTest() {
         val recorder = executeTestsForClass(TestSpek::class)
 
         assertThat(recorder.testFailureCount, equalTo(2))
-        assertThat(counter, equalTo(0))
+        assertThat(counter, equalTo(2))
     }
 
     @Test
@@ -71,7 +71,6 @@ class AfterEachTest: AbstractSpekTestEngineTest() {
         class TestSpek: Spek({
             group("group") {
                 test("test") { }
-                test("another test") { }
                 test("failing test") { assertThat(true, equalTo(false)) }
                 afterEach { counter++ }
             }

--- a/spek-junit-engine/src/test/kotlin/org/jetbrains/spek/engine/CleanupTest.kt
+++ b/spek-junit-engine/src/test/kotlin/org/jetbrains/spek/engine/CleanupTest.kt
@@ -1,0 +1,106 @@
+package org.jetbrains.spek.engine
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.engine.support.AbstractSpekTestEngineTest
+import org.junit.gen5.api.Test
+import java.io.Closeable
+
+class CleanupTest: AbstractSpekTestEngineTest() {
+
+    class TestCloseable : Closeable {
+        var closed = false ; private set
+        override fun close() { closed = true }
+    }
+
+    @Test
+    fun testSuccess() {
+        closeable = TestCloseable()
+        class TestSpek: Spek({
+            group("group") {
+                test("test") {
+                    closeable.autoCleanup()
+                }
+            }
+        })
+
+        executeTestsForClass(TestSpek::class)
+        assertThat(closeable.closed, equalTo(true))
+    }
+
+    @Test
+    fun testFailure() {
+        closeable = TestCloseable()
+        class TestSpek: Spek({
+            group("group") {
+                test("test") {
+                    closeable.autoCleanup()
+                    assertThat(true, equalTo(false))
+                }
+            }
+        })
+
+        executeTestsForClass(TestSpek::class)
+        assertThat(closeable.closed, equalTo(true))
+    }
+
+    @Test
+    fun testBeforeEachFail() {
+        closeable = TestCloseable()
+        class TestSpek: Spek({
+            group("group") {
+                beforeEach {
+                    closeable.autoCleanup()
+                    assertThat(true, equalTo(false))
+                }
+                test("test") { }
+            }
+        })
+
+        executeTestsForClass(TestSpek::class)
+        assertThat(closeable.closed, equalTo(true))
+    }
+
+    @Test
+    fun testPreviousBeforeEachFail() {
+        closeable = TestCloseable()
+        class TestSpek: Spek({
+            group("group") {
+                beforeEach {
+                    assertThat(true, equalTo(false))
+                }
+                beforeEach {
+                    closeable.autoCleanup()
+                }
+                test("test") { }
+            }
+        })
+
+        executeTestsForClass(TestSpek::class)
+        assertThat(closeable.closed, equalTo(false))
+    }
+
+    @Test
+    fun testAfterEachFail() {
+        closeable = TestCloseable()
+        class TestSpek: Spek({
+            group("group") {
+                afterEach {
+                    assertThat(true, equalTo(false))
+                }
+                test("test") {
+                    closeable.autoCleanup()
+                }
+            }
+        })
+
+        executeTestsForClass(TestSpek::class)
+        assertThat(closeable.closed, equalTo(true))
+    }
+
+    companion object {
+        lateinit var closeable: TestCloseable
+    }
+
+}


### PR DESCRIPTION
This PR is the same as #100 but for the branch junit5. You can read its description for a full understanding of this PR ;)

The exact same description applies:
- It makes sure that cleanup code (including `afterEach`) is called even if the test has failed
- It introduces a new idiom for post-run resource cleanup (`onCleanup` and `Closeable.autoCleanup`)
