### PR TITLE
Bad dependency name

### DIFF
--- a/documentation/src/docs/latest/setting-up.adoc
+++ b/documentation/src/docs/latest/setting-up.adoc
@@ -24,7 +24,7 @@ junitPlatform {
 // setup dependencies
 dependencies {
     testCompile 'org.jetbrains.spek:spek-api:{version}'
-    testRuntime 'org.jetbrains.spek:spek-junit-engine:{version}'
+    testRuntime 'org.jetbrains.spek:spek-junit-platform-engine:{version}'
 }
 ----
 


### PR DESCRIPTION
spek-junit-platform-engine not exsists only spek-junit-platform-engine
http://search.maven.org/#artifactdetails%7Corg.jetbrains.spek%7Cspek-junit-platform-engine%7C1.0.77%7Cjar