### PR TITLE
Add return statement when artifact related values are "nothing".

### DIFF
--- a/spek-dist/build.gradle
+++ b/spek-dist/build.gradle
@@ -142,6 +142,9 @@ bintray {
 }
 
 artifactory {
+    if ([artifactory_contextUrl, artifactory_user, artifactory_password].contains("nothing")) {
+        return
+    }
     contextUrl = "${artifactory_contextUrl}"
     publish {
         repository {


### PR DESCRIPTION
## Change

- Add return statement when artifact related values are "nothing".
- This change is just in case for contributor's local env.

### Why?

When I tried to build this on my local, I got the following error since it failed to authenticate.

<img width="872" alt="screen shot 2016-10-02 at 14 45 11" src="https://cloud.githubusercontent.com/assets/471318/19018970/8a638008-88af-11e6-9ebb-ff3f73df238d.png">