### PR TITLE
updated to junitplatform milestone 3 (M3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.8'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.1.0'
-        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-M2'
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-M3'
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
         classpath 'org.ajoberstar:gradle-git:1.5.1'
 

--- a/documentation/src/docs/latest/setting-up.adoc
+++ b/documentation/src/docs/latest/setting-up.adoc
@@ -101,7 +101,7 @@ First, add the required dependencies.
 dependencies {
     testCompile 'org.jetbrains.spek:spek-api:1.0.89'
     testCompile 'org.jetbrains.spek:spek-junit-platform-engine:1.0.89'
-    testCompile 'org.junit.platform:junit-platform-runner:1.0.0-M2'
+    testCompile 'org.junit.platform:junit-platform-runner:1.0.0-M3'
 }
 ----
 

--- a/gradle/common/dependencies.gradle
+++ b/gradle/common/dependencies.gradle
@@ -11,13 +11,13 @@ dependencyManagement {
         dependency 'org.slf4j:slf4j-api:1.7.21'
         dependency 'ch.qos.logback:logback-classic:1.1.7'
 
-        dependencySet(group: 'org.junit.platform', version: '1.0.0-M2') {
+        dependencySet(group: 'org.junit.platform', version: '1.0.0-M3') {
             entry 'junit-platform-engine'
             entry 'junit-platform-runner'
             entry 'junit-platform-launcher'
         }
 
-        dependencySet(group: 'org.junit.jupiter', version: '5.0.0-M2') {
+        dependencySet(group: 'org.junit.jupiter', version: '5.0.0-M3') {
             entry 'junit-jupiter-api'
             entry 'junit-jupiter-engine'
         }

--- a/spek-junit-platform-engine/build.gradle
+++ b/spek-junit-platform-engine/build.gradle
@@ -4,9 +4,11 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'org.jetbrains.dokka'
 
 junitPlatform {
-    platformVersion '1.0.0-M2'
-    engines {
-        exclude 'spek'
+    platformVersion '1.0.0-M3'
+    filters {
+        engines {
+            exclude 'spek'
+        }
     }
 }
 

--- a/spek-samples/build.gradle
+++ b/spek-samples/build.gradle
@@ -3,9 +3,11 @@ apply from: "$rootDir/gradle/common/kotlin.gradle"
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 junitPlatform {
-    platformVersion '1.0.0-M2'
-    engines {
-        include 'spek'
+    platformVersion '1.0.0-M3'
+    filters {
+        engines {
+            include 'spek'
+        }
     }
 }
 


### PR DESCRIPTION
Spek suddenly quit working for us and it appeared to be the junitplatform plugin automatically using the M3 update.  This seemed to solve the issue for us.  Please let me know if there are standards I'm not following.  