### PR TITLE
Gradle script fix

### DIFF
--- a/documentation/src/asciidoc/setting-up.adoc
+++ b/documentation/src/asciidoc/setting-up.adoc
@@ -15,7 +15,9 @@ JUnit Platform provides a http://junit.org/junit5/docs/current/user-guide/#runni
 ----
 // setup the plugin
 buildscript {
-    classpath 'org.junit.platform:junit-platform-gradle-plugin:{junitPlatformVersion}'
+    dependencies {
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:{junitPlatformVersion}'
+    }
 }
 
 apply plugin: 'org.junit.platform.gradle.plugin'


### PR DESCRIPTION
JUnit plugin classpath must be declared in dependencies section (as in Kotlin script)