### PR TITLE
Feature/print stacktrace for exceptions

### DIFF
--- a/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/ThrowableCollector.kt
+++ b/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/ThrowableCollector.kt
@@ -25,10 +25,10 @@ class ThrowableCollector {
 
     fun isEmpty() = throwable == null
 
-
     fun assertEmpty() {
-        if (throwable != null) {
-            throw throwable!!
+        throwable?.let {
+            if (it !is AssertionError) it.printStackTrace()
+            throw it
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/JetBrains/spek/issues/160
 
If the test code throws an exception inside an action body there are no stacktrace to know what happened. 