### PR TITLE
Make default InstanceFactory more lenient

### DIFF
--- a/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
+++ b/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
@@ -40,7 +40,8 @@ class SpekTestEngine: HierarchicalTestEngine<SpekExecutionContext>() {
 
     val defaultInstanceFactory = object: InstanceFactory {
         override fun <T: Spek> create(spek: KClass<T>): T {
-            return spek.objectInstance ?: spek.primaryConstructor!!.call()
+            return spek.objectInstance ?: spek.constructors.first { it.parameters.isEmpty() }
+                .call()
         }
     }
 

--- a/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/InstanceFactoryTest.kt
+++ b/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/InstanceFactoryTest.kt
@@ -28,6 +28,18 @@ class InstanceFactoryTest: AbstractSpekTestEngineTest() {
     }
 
     @Test
+    fun testDefaultUsingSecondaryConstructors() {
+        class SomeSpec(number: Int): Spek({
+            it("should be $number") { }
+        }) {
+            constructor(): this(10)
+        }
+
+        val recorder = executeTestsForClass(SomeSpec::class)
+        assertThat(recorder.testSuccessfulCount, equalTo(1))
+    }
+
+    @Test
     fun testUsingObject() {
         @CreateWith(SimpleFactoryAsAnObject::class)
         class SomeSpec: Spek({


### PR DESCRIPTION
Resolves #171, no-arg secondary constructors will
now also be considered. If you have multiple no-arg
constructors, behaviour is undefined.