### PR TITLE
catch unexpected exceptions in groups

### DIFF
--- a/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
+++ b/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
@@ -149,8 +149,16 @@ class SpekTestEngine: HierarchicalTestEngine<SpekExecutionContext>() {
                 root.uniqueId.append(GROUP_SEGMENT_TYPE, description),
                 pending, getSource(), lifecycleManager
             )
-            root.addChild(group)
-            body.invoke(Collector(group, lifecycleManager, fixtures))
+            try {
+                body.invoke(Collector(group, lifecycleManager, fixtures))
+                root.addChild(group)
+            } catch(t: Throwable) {
+                group(description: String, pending, body = {
+                    it("unexpected exception occurred during set up!!!") {
+                        throw t
+                    }
+                })
+            }
 
         }
 


### PR DESCRIPTION
Edited in editor, so no guarantee that it has not mistakes. An idea how to deal with #176