### PR TITLE
Properly handle exceptions during discovery phase

### DIFF
--- a/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
+++ b/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
@@ -150,7 +150,16 @@ class SpekTestEngine: HierarchicalTestEngine<SpekExecutionContext>() {
                 pending, getSource(), lifecycleManager
             )
             root.addChild(group)
-            body.invoke(Collector(group, lifecycleManager, fixtures))
+            val collector = Collector(group, lifecycleManager, fixtures)
+            try {
+                body.invoke(collector)
+            } catch (e: Throwable) {
+                collector.beforeGroup { throw e }
+                group.addChild(Scope.Test(
+                    root.uniqueId.append(TEST_SEGMENT_TYPE, "Group failure"),
+                    pending, getSource(), lifecycleManager, {}
+                ))
+            }
 
         }
 

--- a/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/FailingGroupTest.kt
+++ b/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/FailingGroupTest.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.spek.engine
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.engine.support.AbstractSpekTestEngineTest
+import org.junit.jupiter.api.Test
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+class FailingGroupTest: AbstractSpekTestEngineTest() {
+    @Test
+    fun testFailingGroup() {
+        class FailingSpec: Spek({
+
+            group("some failing group") {
+                throw RuntimeException()
+                test("this won't be executed") { }
+            }
+
+            group("some group") {
+                test("do something") { }
+                test("do another thing") { }
+            }
+        })
+
+        val recorder = executeTestsForClass(FailingSpec::class)
+
+        assertThat(recorder.containerFailureCount, equalTo(1))
+        assertThat(recorder.testSuccessfulCount, equalTo(2))
+    }
+}


### PR DESCRIPTION
Ignore failing groups during discovery phase. Passing groups will now
be properly discovered by Spek.

Resolves #176.