### PR TITLE
Point out necessity of setting -ea VM option when using Kotlin's built-in or kotlin-test assertions

### DIFF
--- a/documentation/src/asciidoc/writing-specifications.adoc
+++ b/documentation/src/asciidoc/writing-specifications.adoc
@@ -3,7 +3,7 @@
 === Assertion Framework
 Spek doesn't have any built-in assertions, luckily there are several libraries in the wild that do. Below are several suggestions:
 
-- `org.jetbrains.kotlin:kotlin-test`
+- `org.jetbrains.kotlin:kotlin-test` (make sure to use the `-ea` VM option in your Spek run configuration when using this one or Kotlin's built in assertions)
 - https://github.com/npryce/hamkrest[HamKrest]
 - https://github.com/winterbe/expekt[Expekt]
 - https://github.com/MarkusAmshove/Kluent[Kluent]


### PR DESCRIPTION
Fiddled around with this one quite a bit before getting Kotlin's built-in and kotlin-test assertions to work. This is no particular issue with Spek, but we want to be friendly citizens of the internet and thus should inform our fellow devs about the importance of these three chars. Without them tests will always pass in the IDE when using this particular configuration.