### PR TITLE
Introduce CachingMode.SCOPE

### DIFF
--- a/spek-api/src/main/kotlin/org/jetbrains/spek/api/lifecycle/CachingMode.kt
+++ b/spek-api/src/main/kotlin/org/jetbrains/spek/api/lifecycle/CachingMode.kt
@@ -10,9 +10,16 @@ import org.jetbrains.spek.meta.Experimental
 @Experimental
 enum class CachingMode {
     /**
-     * Instance will be shared within the group it was declared.
+     * Each group will get their own unique instance. Nested groups will have
+     * their own unique instance as well.
      */
     GROUP,
+
+    /**
+     * Instance will be shared within the group it was declared.
+     */
+    SCOPE,
+
     /**
      * Each test will get their own unique instance.
      */

--- a/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
+++ b/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
@@ -135,7 +135,12 @@ class SpekTestEngine: HierarchicalTestEngine<SpekExecutionContext>() {
                          val fixtures: FixturesAdapter): Spec {
 
         override fun <T> memoized(mode: CachingMode, factory: () -> T): LifecycleAware<T> {
-            return LifecycleAwareAdapter(mode, factory).apply {
+            val adapter = when (mode) {
+                CachingMode.GROUP -> LifecycleAwareAdapter.GroupCachingModeAdapter(factory)
+                CachingMode.TEST -> LifecycleAwareAdapter.TestCachingModeAdapter(factory)
+                CachingMode.SCOPE -> LifecycleAwareAdapter.ScopeCachingModeAdapter(root, factory)
+            }
+            return adapter.apply {
                 registerListener(this)
             }
         }

--- a/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/MemoizedTest.kt
+++ b/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/MemoizedTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
  */
 class MemoizedTest: AbstractSpekTestEngineTest() {
     @Test
-    fun testMemoizedTestCaching() {
+    fun memoizedTestCaching() {
         class MemoizedSpec: Spek({
             val foo = memoized {
                 listOf(1)
@@ -41,7 +41,7 @@ class MemoizedTest: AbstractSpekTestEngineTest() {
     }
 
     @Test
-    fun testMemoizedGroupCaching() {
+    fun memoizedGroupCaching() {
         class MemoizedSpec: Spek({
             val foo = memoized(CachingMode.GROUP) {
                 listOf(1)
@@ -50,13 +50,86 @@ class MemoizedTest: AbstractSpekTestEngineTest() {
             var memoized1: List<Int>? = null
             var memoized2: List<Int>? = null
 
-            test("first pass") {
-                memoized1 = foo()
+            group("group") {
+                test("first pass") {
+                    memoized1 = foo()
+                }
             }
 
-            test("second pass") {
-                memoized2 = foo()
+            group("another group") {
+                test("second pass") {
+                    memoized2 = foo()
+                }
+
             }
+
+
+            test("check") {
+                assertThat(memoized1, !sameInstance(memoized2))
+            }
+        })
+
+        val recorder = executeTestsForClass(MemoizedSpec::class)
+
+        assertThat(recorder.testFailureCount, equalTo(0))
+    }
+
+    @Test
+    fun memoizedNestedGroupCaching() {
+        class MemoizedSpec: Spek({
+            val foo = memoized(CachingMode.GROUP) {
+                listOf(1)
+            }
+
+            var memoized1: List<Int>? = null
+            var memoized2: List<Int>? = null
+
+            group("group") {
+                test("first pass") {
+                    memoized1 = foo()
+                }
+
+                group("another group") {
+                    test("second pass") {
+                        memoized2 = foo()
+                    }
+
+                }
+            }
+
+            test("check") {
+                assertThat(memoized1, !sameInstance(memoized2))
+            }
+        })
+
+        val recorder = executeTestsForClass(MemoizedSpec::class)
+
+        assertThat(recorder.testFailureCount, equalTo(0))
+    }
+
+    @Test
+    fun memoizedScopeCaching() {
+        class MemoizedSpec: Spek({
+            val foo = memoized(CachingMode.SCOPE) {
+                listOf(1)
+            }
+
+            var memoized1: List<Int>? = null
+            var memoized2: List<Int>? = null
+
+            group("group") {
+                test("first pass") {
+                    memoized1 = foo()
+                }
+            }
+
+            group("another group") {
+                test("second pass") {
+                    memoized2 = foo()
+                }
+
+            }
+
 
             test("check") {
                 assertThat(memoized1, sameInstance(memoized2))
@@ -69,7 +142,41 @@ class MemoizedTest: AbstractSpekTestEngineTest() {
     }
 
     @Test
-    fun testMemoizedActionCaching() {
+    fun memoizedScopeCachingWithNestedGroups() {
+        class MemoizedSpec: Spek({
+            val foo = memoized(CachingMode.SCOPE) {
+                listOf(1)
+            }
+
+            var memoized1: List<Int>? = null
+            var memoized2: List<Int>? = null
+
+            group("group") {
+                test("first pass") {
+                    memoized1 = foo()
+                }
+
+                group("another group") {
+                    test("second pass") {
+                        memoized2 = foo()
+                    }
+
+                }
+            }
+
+            test("check") {
+                assertThat(memoized1, sameInstance(memoized2))
+            }
+        })
+
+        val recorder = executeTestsForClass(MemoizedSpec::class)
+
+        assertThat(recorder.testFailureCount, equalTo(0))
+    }
+
+
+    @Test
+    fun memoizedActionCaching() {
         class MemoizedSpec: Spek({
             val foo = memoized {
                 listOf(1)


### PR DESCRIPTION
In this mode instances will be cached within the group the memoized
was created. This has the same semantics with `beforeGroup` and a local
variable declaration.

Resolves #165.