### PR TITLE
Remove subject dependency from junit-platform-engine

### DIFF
--- a/spek-junit-platform-engine/build.gradle
+++ b/spek-junit-platform-engine/build.gradle
@@ -14,7 +14,6 @@ junitPlatform {
 
 dependencies {
     compile project(':spek-api')
-    compile project(':spek-subject-extension')
 
     compile 'org.jetbrains.kotlin:kotlin-stdlib'
     compile 'org.jetbrains.kotlin:kotlin-reflect'

--- a/spek-subject-extension/build.gradle
+++ b/spek-subject-extension/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib'
     compile 'org.jetbrains.kotlin:kotlin-reflect'
 
+    testCompile project(':spek-junit-platform-engine')
     testCompile 'org.junit.jupiter:junit-jupiter-api'
     testCompile project(':junit-platform-engine-test-support')
 


### PR DESCRIPTION
This essentially make subjects an opt-in feature.

Resolves #152 and resolves #153.