### PR TITLE
Fix itBehavesLike for subjects

### DIFF
--- a/spek-subject-extension/src/main/kotlin/org/jetbrains/spek/subject/Shared.kt
+++ b/spek-subject-extension/src/main/kotlin/org/jetbrains/spek/subject/Shared.kt
@@ -10,27 +10,29 @@ import org.jetbrains.spek.subject.dsl.SubjectDsl
 import org.jetbrains.spek.subject.dsl.SubjectProviderDsl
 import kotlin.reflect.KProperty
 
+class IncludedSubjectSpek<T>(val adapter: LifecycleAware<T>, spec: Spec): SubjectProviderDsl<T>, Spec by spec {
+    override fun subject() = adapter
+    override fun subject(mode: CachingMode, factory: () -> T): LifecycleAware<T> {
+        return adapter
+    }
+    override val subject: T
+        get() = adapter()
+}
+
 @Experimental
 infix fun <T, K: T> SubjectDsl<K>.itBehavesLike(spec: SubjectSpek<T>) {
     include(Spek.wrap {
-        val value: SubjectProviderDsl<T> = object: SubjectProviderDsl<T>, Spec by this {
-            val adapter = object: LifecycleAware<T> {
-                override fun getValue(thisRef: Any?, property: KProperty<*>): T {
-                    return this()
-                }
-
-                override fun invoke(): T {
-                    return this@itBehavesLike.subject().invoke()
-                }
-
+        val adapter = object: LifecycleAware<T> {
+            override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+                return this()
             }
 
-            override fun subject() = adapter
-            override fun subject(mode: CachingMode, factory: () -> T) = adapter
-            override val subject: T
-                get() = adapter()
+            override fun invoke(): T {
+                return this@itBehavesLike.subject().invoke()
+            }
 
         }
-        spec.spec(value)
+        spec.spec.invoke(IncludedSubjectSpek(adapter, this))
     })
+
 }

--- a/spek-subject-extension/src/main/kotlin/org/jetbrains/spek/subject/Shared.kt
+++ b/spek-subject-extension/src/main/kotlin/org/jetbrains/spek/subject/Shared.kt
@@ -10,7 +10,7 @@ import org.jetbrains.spek.subject.dsl.SubjectDsl
 import org.jetbrains.spek.subject.dsl.SubjectProviderDsl
 import kotlin.reflect.KProperty
 
-class IncludedSubjectSpek<T>(val adapter: LifecycleAware<T>, spec: Spec): SubjectProviderDsl<T>, Spec by spec {
+internal class IncludedSubjectSpek<T>(val adapter: LifecycleAware<T>, spec: Spec): SubjectProviderDsl<T>, Spec by spec {
     override fun subject() = adapter
     override fun subject(mode: CachingMode, factory: () -> T): LifecycleAware<T> {
         return adapter

--- a/spek-subject-extension/src/main/kotlin/org/jetbrains/spek/subject/SubjectSpek.kt
+++ b/spek-subject-extension/src/main/kotlin/org/jetbrains/spek/subject/SubjectSpek.kt
@@ -10,5 +10,9 @@ import org.jetbrains.spek.subject.dsl.SubjectProviderDsl
  */
 @Experimental
 abstract class SubjectSpek<T>(val subjectSpec: SubjectProviderDsl<T>.() -> Unit): Spek({
-    subjectSpec.invoke(SubjectProviderDslImpl(this))
+    if (this is IncludedSubjectSpek<*>) {
+        subjectSpec.invoke(this as IncludedSubjectSpek<T>)
+    } else {
+        subjectSpec.invoke(SubjectProviderDslImpl(this))
+    }
 })

--- a/spek-subject-extension/src/test/kotlin/org/jetbrains/spek/subject/IncludeSubjectTest.kt
+++ b/spek-subject-extension/src/test/kotlin/org/jetbrains/spek/subject/IncludeSubjectTest.kt
@@ -1,0 +1,42 @@
+package org.jetbrains.spek.subject
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.on
+import org.jetbrains.spek.engine.SpekTestEngine
+import org.jetbrains.spek.engine.test.AbstractJUnitTestEngineTest
+import org.junit.jupiter.api.Test
+import java.util.ArrayDeque
+import java.util.LinkedList
+import java.util.Queue
+
+class IncludeSubjectTest: AbstractJUnitTestEngineTest<SpekTestEngine>(SpekTestEngine()) {
+
+    @Test
+    fun itShouldOverrideNestedSubject() {
+        class JavaQueueSpec : SubjectSpek<Queue<String>>({
+            subject {
+                LinkedList()
+            }
+
+            describe("whatever") {
+                on("pushing an item") {
+                    subject.offer("Hi")
+                }
+            }
+        })
+
+        class ArrayDequeSpec : SubjectSpek<ArrayDeque<String>>({
+            subject {
+                // all tests should fail because of this
+                throw Throwable()
+            }
+
+            itBehavesLike(JavaQueueSpec())
+        })
+
+        val recorder = executeTestsForClass(ArrayDequeSpec::class)
+        assertThat(recorder.testSuccessfulCount, equalTo(0))
+    }
+}


### PR DESCRIPTION
SubjectSpek's will now properly override subjects of nested SubjectSpek's.