### PR TITLE
Use 'attributes+' sub instead of 'attributes' to display code correctly

### DIFF
--- a/documentation/src/asciidoc/setting-up.adoc
+++ b/documentation/src/asciidoc/setting-up.adoc
@@ -42,7 +42,7 @@ dependencies {
 ----
 
 === Gradle Kotlin Script
-[source,kotlin,subs="attributes"]
+[source,kotlin,subs="attributes+"]
 .build.gradle.kts
 ----
 import org.gradle.api.plugins.ExtensionAware


### PR DESCRIPTION
The generic <JUnitPlatformExtension> isn's displayed and causes some confusion