### PR TITLE
Add extensions for Data4-Data9 types

### DIFF
--- a/spek-data-driven-extension/src/main/kotlin/org/jetbrains/spek/data_driven/namespace.kt
+++ b/spek-data-driven-extension/src/main/kotlin/org/jetbrains/spek/data_driven/namespace.kt
@@ -32,6 +32,60 @@ inline fun <reified I1, reified I2, reified I3, reified Expected> SpecBody.on(de
     }
 }
 
+inline fun <reified I1, reified I2, reified I3, reified I4, reified Expected> SpecBody.on(description: String, vararg with: Data4<I1, I2, I3, I4, Expected>, crossinline body: ActionBody.(i1: I1, i2: I2, i3: I3, i4: I4, e: Expected) -> Unit) {
+    with.forEach {
+        val (input1, input2, input3, input4, expected) = it
+        defaultOn(description = description.format(input1, input2, input3, input4, expected)) {
+            body(this, input1, input2, input3, input4, expected)
+        }
+    }
+}
+
+inline fun <reified I1, reified I2, reified I3, reified I4, reified I5, reified Expected> SpecBody.on(description: String, vararg with: Data5<I1, I2, I3, I4, I5, Expected>, crossinline body: ActionBody.(i1: I1, i2: I2, i3: I3, i4: I4, i5: I5, e: Expected) -> Unit) {
+    with.forEach {
+        val (input1, input2, input3, input4, input5, expected) = it
+        defaultOn(description = description.format(input1, input2, input3, input4, input5, expected)) {
+            body(this, input1, input2, input3, input4, input5, expected)
+        }
+    }
+}
+
+inline fun <reified I1, reified I2, reified I3, reified I4, reified I5, reified I6, reified Expected> SpecBody.on(description: String, vararg with: Data6<I1, I2, I3, I4, I5, I6, Expected>, crossinline body: ActionBody.(i1: I1, i2: I2, i3: I3, i4: I4, i5: I5, i6: I6, e: Expected) -> Unit) {
+    with.forEach {
+        val (input1, input2, input3, input4, input5, input6, expected) = it
+        defaultOn(description = description.format(input1, input2, input3, input4, input5, input6, expected)) {
+            body(this, input1, input2, input3, input4, input5, input6, expected)
+        }
+    }
+}
+
+inline fun <reified I1, reified I2, reified I3, reified I4, reified I5, reified I6, reified I7, reified Expected> SpecBody.on(description: String, vararg with: Data7<I1, I2, I3, I4, I5, I6, I7, Expected>, crossinline body: ActionBody.(i1: I1, i2: I2, i3: I3, i4: I4, i5: I5, i6: I6, i7: I7, e: Expected) -> Unit) {
+    with.forEach {
+        val (input1, input2, input3, input4, input5, input6, input7, expected) = it
+        defaultOn(description = description.format(input1, input2, input3, input4, input5, input6, input7, expected)) {
+            body(this, input1, input2, input3, input4, input5, input6, input7, expected)
+        }
+    }
+}
+
+inline fun <reified I1, reified I2, reified I3, reified I4, reified I5, reified I6, reified I7, reified I8, reified Expected> SpecBody.on(description: String, vararg with: Data8<I1, I2, I3, I4, I5, I6, I7, I8, Expected>, crossinline body: ActionBody.(i1: I1, i2: I2, i3: I3, i4: I4, i5: I5, i6: I6, i7: I7, i8: I8, e: Expected) -> Unit) {
+    with.forEach {
+        val (input1, input2, input3, input4, input5, input6, input7, input8, expected) = it
+        defaultOn(description = description.format(input1, input2, input3, input4, input5, input6, input7, input8, expected)) {
+            body(this, input1, input2, input3, input4, input5, input6, input7, input8, expected)
+        }
+    }
+}
+
+inline fun <reified I1, reified I2, reified I3, reified I4, reified I5, reified I6, reified I7, reified I8,  reified I9, reified Expected> SpecBody.on(description: String, vararg with: Data9<I1, I2, I3, I4, I5, I6, I7, I8, I9, Expected>, crossinline body: ActionBody.(i1: I1, i2: I2, i3: I3, i4: I4, i5: I5, i6: I6, i7: I7, i8: I8, i9: I9, e: Expected) -> Unit) {
+    with.forEach {
+        val (input1, input2, input3, input4, input5, input6, input7, input8, input9, expected) = it
+        defaultOn(description = description.format(input1, input2, input3, input4, input5, input6, input7, input8, input9, expected)) {
+            body(this, input1, input2, input3, input4, input5, input6, input7, input8, input9, expected)
+        }
+    }
+}
+
 data class Data1<I1, Expected>(val input1: I1, val expected: Expected)
 data class Data2<I1, I2, Expected>(val input1: I1, val input2: I2, val expected: Expected)
 data class Data3<I1, I2, I3, Expected>(val input1: I1, val input2: I2, val input3: I3, val expected: Expected)


### PR DESCRIPTION
Added extensions for `on` function. Issue #212 
Although, this should be handled in a generic way. 