### PR TITLE
Rework path creation and serialization

### DIFF
--- a/spek-extensions/subject/src/test/kotlin/org/spekframework/spek2/subject/IncludeSubjectTest.kt
+++ b/spek-extensions/subject/src/test/kotlin/org/spekframework/spek2/subject/IncludeSubjectTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.dsl.describe
 import org.spekframework.spek2.dsl.on
+import org.spekframework.spek2.jvm.JvmPathBuilder
 import org.spekframework.spek2.jvm.SpekJvmRuntime
-import org.spekframework.spek2.jvm.classToPath
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.test.AbstractSpekRuntimeTest
 import java.util.ArrayDeque
@@ -46,6 +46,7 @@ class IncludeSubjectTest: AbstractSpekRuntimeTest<SpekJvmRuntime>(SpekJvmRuntime
 
     // FIXME: duplicate
     override fun toPath(spek: KClass<out Spek>): Path {
-        return classToPath(spek)
+        return JvmPathBuilder.from(spek)
+            .build()
     }
 }

--- a/spek-runners/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
+++ b/spek-runners/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
@@ -4,7 +4,7 @@ import org.junit.platform.engine.EngineDiscoveryRequest
 import org.junit.platform.engine.TestDescriptor
 import org.junit.platform.engine.TestEngine
 import org.junit.platform.engine.UniqueId
-import org.spekframework.spek2.jvm.JvmPath
+import org.spekframework.spek2.jvm.JvmPathBuilder
 import org.spekframework.spek2.jvm.SpekJvmRuntime
 import org.spekframework.spek2.runtime.execution.DiscoveryRequest
 import org.spekframework.spek2.runtime.execution.ExecutionRequest
@@ -21,7 +21,7 @@ class SpekTestEngine: TestEngine {
         val engineDescriptor = SpekEngineDescriptor(uniqueId, id)
 
         val pathSelector = discoveryRequest.getSelectorsByType(PathSelector::class.java)
-            .firstOrNull() ?: PathSelector(JvmPath.ROOT)
+            .firstOrNull() ?: PathSelector(JvmPathBuilder.ROOT)
 
         val discoveryResult = runtime.discover(DiscoveryRequest(pathSelector.path))
 

--- a/spek-runners/junit5/src/test/kotlin/org/spekframework/spek2/junit/TestDescriptorAdapterFactoryTest.kt
+++ b/spek-runners/junit5/src/test/kotlin/org/spekframework/spek2/junit/TestDescriptorAdapterFactoryTest.kt
@@ -6,7 +6,7 @@ import com.nhaarman.mockito_kotlin.mock
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.spekframework.spek2.dsl.Pending
-import org.spekframework.spek2.jvm.JvmPath
+import org.spekframework.spek2.jvm.JvmPathBuilder
 import org.spekframework.spek2.runtime.lifecycle.LifecycleManager
 import org.spekframework.spek2.runtime.scope.GroupScopeImpl
 import org.spekframework.spek2.runtime.scope.ScopeId
@@ -27,9 +27,13 @@ class TestDescriptorAdapterFactoryTest {
 
     @Test
     fun caching() {
+        val path = JvmPathBuilder()
+            .append("SomeClass")
+            .build()
+
         val scope = GroupScopeImpl(
             ScopeId(ScopeType.CLASS, "SomeClass"),
-            JvmPath.from(("SomeClass")),
+            path,
             null,
             Pending.No,
             lifecycleManager

--- a/spek-runtimes/common/src/main/kotlin/org/spekframework/spek2/runtime/scope/Path.kt
+++ b/spek-runtimes/common/src/main/kotlin/org/spekframework/spek2/runtime/scope/Path.kt
@@ -18,3 +18,9 @@ val Path.isRoot: Boolean
 // 1: my.package/MyClass -> my.package/MyClass/description
 // 2: my.package/MyClass/description -> my.package/MyClass
 fun Path.isRelated(path: Path) = this.isParentOf(path) || path.isParentOf(this)
+
+
+interface PathBuilder {
+    fun append(name: String): PathBuilder
+    fun build(): Path
+}

--- a/spek-runtimes/jvm/src/main/kotlin/org/spekframework/spek2/jvm/JvmPath.kt
+++ b/spek-runtimes/jvm/src/main/kotlin/org/spekframework/spek2/jvm/JvmPath.kt
@@ -60,7 +60,7 @@ private data class JvmPath constructor(override val name: String, override val p
     }
 }
 
-class JvmPathBuilder private constructor(val parent: JvmPath): PathBuilder {
+class JvmPathBuilder private constructor(private val parent: JvmPath): PathBuilder {
     constructor(): this(ROOT as JvmPath)
 
     override fun append(name: String): PathBuilder {

--- a/spek-runtimes/jvm/src/main/kotlin/org/spekframework/spek2/jvm/SpekJvmRuntime.kt
+++ b/spek-runtimes/jvm/src/main/kotlin/org/spekframework/spek2/jvm/SpekJvmRuntime.kt
@@ -36,8 +36,18 @@ class SpekJvmRuntime: SpekRuntime() {
             .map(Class<out Spek>::kotlin)
             .filter { it.findAnnotation<Ignore>() == null }
             .filter { !it.isAbstract }
-            .filter { discoveryRequest.path.isRelated(classToPath(it)) }
-            .map { resolveSpec(it, classToPath(it)) }
+            .filter {
+                val path = JvmPathBuilder.from(it)
+                    .build()
+
+                discoveryRequest.path.isRelated(path)
+            }
+            .map {
+                val path = JvmPathBuilder.from(it)
+                    .build()
+
+                resolveSpec(it, path)
+            }
             // TODO: should we move final filtering to SpekRuntime?
             .map { it.apply { filterBy(discoveryRequest.path) } }
             .filter { !it.isEmpty() }

--- a/spek-runtimes/jvm/src/test/kotlin/org/spekframework/spek2/jvm/JvmPathSpec.kt
+++ b/spek-runtimes/jvm/src/test/kotlin/org/spekframework/spek2/jvm/JvmPathSpec.kt
@@ -1,0 +1,52 @@
+package org.spekframework.spek2.jvm
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import org.spekframework.spek2.Spek
+
+class JvmPathSpec {
+
+    @Test
+    fun create() {
+        val path = JvmPathBuilder()
+            .append("com.example.com")
+            .append("SomeClass")
+            .build()
+
+        assertThat(path.name, equalTo("SomeClass"))
+        assertThat(path.parent!!.name, equalTo("com.example.com"))
+    }
+
+    @Test
+    fun root() {
+        val path = JvmPathBuilder()
+            .append("com.example.com")
+            .append("SomeClass")
+            .build()
+
+        assertThat(path.parent!!.parent!!.name, equalTo(""))
+    }
+
+    @Test
+    fun createFromClass() {
+        val path = JvmPathBuilder.from(Spek::class)
+            .build()
+
+        assertThat(path.name, equalTo(Spek::class.simpleName))
+        assertThat(path.parent!!.name, equalTo(Spek::class.java.`package`.name))
+    }
+
+    @Test
+    fun parse() {
+        val path = JvmPathBuilder()
+            .append("com.example.com")
+            .append("SomeClass")
+            .build()
+
+        val result = JvmPathBuilder.parse(path.serialize())
+            .build()
+
+        assertThat(path, equalTo(result))
+    }
+}

--- a/spek-runtimes/jvm/src/test/kotlin/org/spekframework/spek2/jvm/support/AbstractSpekJvmRuntimeTest.kt
+++ b/spek-runtimes/jvm/src/test/kotlin/org/spekframework/spek2/jvm/support/AbstractSpekJvmRuntimeTest.kt
@@ -1,14 +1,15 @@
 package org.spekframework.spek2.jvm.support
 
 import org.spekframework.spek2.Spek
+import org.spekframework.spek2.jvm.JvmPathBuilder
 import org.spekframework.spek2.jvm.SpekJvmRuntime
-import org.spekframework.spek2.jvm.classToPath
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.test.AbstractSpekRuntimeTest
 import kotlin.reflect.KClass
 
 abstract class AbstractSpekJvmRuntimeTest: AbstractSpekRuntimeTest<SpekJvmRuntime>(SpekJvmRuntime()) {
     override fun toPath(spek: KClass<out Spek>): Path {
-        return classToPath(spek)
+        return JvmPathBuilder.from(spek)
+            .build()
     }
 }


### PR DESCRIPTION
Simply path serialization, encode `name` using base64 instead of escaping. Deserialization is now much simpler, just have to use `String.split` and decode each path parts.