### PR TITLE
Fix README.md links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 
 
-Visit the [web site](https://jetbrains.github.io/spek) for more documentation and information
+Visit the [web site](http://spekframework.org/) for more documentation and information
 
 
 Copyright (c) 2012-2017, Spek Core Team and Contributors
 
-Licensed under [Modified BSD](https://github.com/JetBrains/spek/blob/master/LICENSE.TXT)
+Licensed under [Modified BSD](https://github.com/spekframework/spek/blob/master/LICENSE.TXT)
 


### PR DESCRIPTION
* Web site link no longer targets 404 page on Github Pages
* Link to license now targets LICENSE.txt without redirect