### PR TITLE
Update JUnit Jupiter 5.0.0 → 5.0.1, JUnit Platform 1.0.0 → 1.0.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.13'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.1.0'
-        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-RC2'
+        classpath "org.junit.platform:junit-platform-gradle-plugin:$junitPlatformVersion"
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
         classpath 'org.ajoberstar:gradle-git:1.5.1'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlinVersion=1.1.3
-junitPlatformVersion=1.0.0
+junitPlatformVersion=1.0.1
 kotlin.incremental=true
 githubRepo=https://github.com/spekframework/spek
 issueTracker=https://github.com/spekframework/spek/issues

--- a/gradle/common/dependencies.gradle
+++ b/gradle/common/dependencies.gradle
@@ -10,7 +10,7 @@ dependencyManagement {
             entry 'junit-platform-launcher'
         }
 
-        dependencySet(group: 'org.junit.jupiter', version: '5.0.0') {
+        dependencySet(group: 'org.junit.jupiter', version: '5.0.1') {
             entry 'junit-jupiter-api'
             entry 'junit-jupiter-engine'
         }

--- a/gradle/common/junit-jupiter.gradle
+++ b/gradle/common/junit-jupiter.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 junitPlatform {
-    platformVersion '1.0.0-M4'
+    platformVersion junitPlatformVersion
     filters {
         engines {
             exclude 'spek'


### PR DESCRIPTION
http://junit.org/junit5/docs/5.0.1/user-guide/#release-notes-5.0.1

No major changes on JUnit side, but what's more important is that this PR makes versions consistent across Spek modules and Gradle setup.