### PR TITLE
Make 'dsl:common' transitive for 'dsl:jvm'.

### DIFF
--- a/spek-dsl/jvm/build.gradle
+++ b/spek-dsl/jvm/build.gradle
@@ -15,3 +15,7 @@ task javadocJar(type: Jar, dependsOn: dokka) {
 dependencies {
     expectedBy project(':spek-dsl:common')
 }
+
+dependencies {
+    compile project(':spek-dsl:common')
+}


### PR DESCRIPTION
Otherwise `samples` project (and probably real users, we'll need to check `pom`) won't be able to write tests in IDE (`spek-dsl:common` is not in IDE test classpath in `samples` project)

<img width="1081" alt="screen shot 2017-10-22 at 00 14 22" src="https://user-images.githubusercontent.com/967132/31859359-8b34e0dc-b6bf-11e7-85b1-3cad04b86177.png">

But what's interesting is that it works from command line, so I guess `kotlin-platform-jvm` doesn't properly generate dependency tree and IDE doesn't see project declared as `expectedBy` (I'm not sure it should, but on first sight it seems that that would be expected) 
