### PR TITLE
Override default Travis install step to avoid unnecessary './gradlew assemble'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: java
 jdk: oraclejdk8
 
 install:
-  - echo "Override default Travis install step to avoid unnecessary './gradlew assemble'."
+  - echo "Overriding default Travis install step to avoid unnecessary './gradlew assemble'."
 
 script:
   - ci/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false
 language: java
 jdk: oraclejdk8
 
+install:
+  - echo "Override default Travis install step to avoid unnecessary './gradlew assemble'."
+
 script:
   - ci/build.sh
   


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/8667 for details, this will speedup all CI builds!