### PR TITLE
Suppress warning for valid unchecked cast.

### DIFF
--- a/spek-extensions/subject/common/src/main/kotlin/org/spekframework/spek2/subject/SubjectSpek.kt
+++ b/spek-extensions/subject/common/src/main/kotlin/org/spekframework/spek2/subject/SubjectSpek.kt
@@ -11,6 +11,7 @@ import org.spekframework.spek2.subject.dsl.SubjectProviderDsl
 @Experimental
 abstract class SubjectSpek<T>(val subjectSpec: SubjectProviderDsl<T>.() -> Unit): Spek({
     if (this is IncludedSubjectSpek<*>) {
+        @Suppress("UNCHECKED_CAST")
         subjectSpec.invoke(this as IncludedSubjectSpek<T>)
     } else {
         subjectSpec.invoke(SubjectProviderDslImpl(this))


### PR DESCRIPTION
Noticed during build:

```console
Unchecked cast: Spec to IncludedSubjectSpek<T>
```

I don't see any ways to properly cast it since generic gets erased, so it looks like something we should just live with.