### PR TITLE
Delete unreachable code from FailingGroupTest.

### DIFF
--- a/spek-runtimes/jvm/src/test/kotlin/org/spekframework/spek2/jvm/FailingGroupTest.kt
+++ b/spek-runtimes/jvm/src/test/kotlin/org/spekframework/spek2/jvm/FailingGroupTest.kt
@@ -16,7 +16,6 @@ class FailingGroupTest: AbstractSpekRuntimeTest() {
 
             group("some failing group") {
                 throw RuntimeException()
-                test("this won't be executed") { }
             }
 
             group("some group") {


### PR DESCRIPTION
Also noticed during build:

```console
FailingGroupTest.kt: (19, 17): Unreachable code
```

Initially I suppressed it, but then decided to remove since Spek has no way to catch exception and continue method invocation there, so it actually doesn't matter if we have this code or not.