### PR TITLE
Fix deprecated assignment of single element to named vararg parameter.

### DIFF
--- a/spek-extensions/data-driven/jvm/src/test/kotlin/org/spekframework/spek2/data_driven/DataDrivenSpec.kt
+++ b/spek-extensions/data-driven/jvm/src/test/kotlin/org/spekframework/spek2/data_driven/DataDrivenSpec.kt
@@ -33,7 +33,7 @@ class DataDrivenSpec : Spek({
             }
         }
 
-        on("%s divided by %s", with = data(10, 2, expected = 5)) { dividend, divisor, result ->
+        on("%s divided by %s", data(10, 2, expected = 5)) { dividend, divisor, result ->
 
             it("returns $result") {
                 assertEquals(calculator.divide(dividend, divisor), result)


### PR DESCRIPTION
```console
DataDrivenSpec.kt: (36, 39): Assigning single elements to varargs in named form is deprecated
```

Now this is actually a bummer, I've read about changes regarding varags but didn't realize it would affect such use cases. See https://blog.jetbrains.com/kotlin/2017/09/kotlin-1-2-beta-is-out/

Can't say I'm a fan of this change, Kotlin 1.2 is still in beta so if you also don't like it we can file an issue and try to revert this syntax deprecation.

Alternative solution could be to create an overload of this function with regular named argument for single parameter, but that would mess our code a little bit and confuse users. 