### PR TITLE
Adjust timestamp in JAR manifests to allow Gradle incremental builds

### DIFF
--- a/gradle/common/kotlin-jvm.gradle
+++ b/gradle/common/kotlin-jvm.gradle
@@ -13,6 +13,6 @@ tasks.withType(Jar) { task ->
             'Implementation-Title': 'Spek', \
             'Implementation-Version': rootProject.version, \
             'Implementation-Kotlin-Version': kotlinVersion, \
-            'Build-Time': new Date().format('yyyy-MM-dd\'T\'HH:mm:ssZ')
+            'Build-Time': System.getenv("TEAMCITY_VERSION") ? new Date().format('yyyy-MM-dd\'T\'HH:mm:ssZ') : new Date(0).format('yyyy-MM-dd\'T\'HH:mm:ssZ')
     }
 }


### PR DESCRIPTION
Adding a timestamp to all JAR manifests causes Gradle's incremental build to always consider all Jar tasks out-of-date.

What this change does is sets the Build-Time to the current time only if it's on TeamCity, and otherwise uses a constant value.
See https://guides.gradle.org/performance/#incremental_build and https://youtu.be/MofXNalZU-E?t=27m55s for more information.