### PR TITLE
list Atrium, an assertion library

### DIFF
--- a/docs/latest/index.html
+++ b/docs/latest/index.html
@@ -871,6 +871,9 @@ in the <code>org.jetbrains.api</code> package.</p>
 <p><code>org.jetbrains.kotlin:kotlin-test</code> (make sure to use the <code>-ea</code> VM option in your Spek run configuration when using this one or Kotlin&#8217;s built in assertions)</p>
 </li>
 <li>
+<p><a href="https://github.com/robstoll/atrium">Atrium</a></p>
+</li>
+<li>
 <p><a href="https://github.com/npryce/hamkrest">HamKrest</a></p>
 </li>
 <li>


### PR DESCRIPTION
Would be nice if you could list Atrium in the list of assertion libraries. Atrium is using Spek itself and I regularly report bugs 