### PR TITLE
Fix cross-module groupId/artifactIds in pom.

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -7,16 +7,17 @@ apply from: "$rootDir/gradle/common/dependencies.gradle"
 description = 'Spek Distribution packages'
 
 
-def artifact(publication, project, artifactName) {
+def artifact(Publication publication, Project project, artifactName) {
     def configure = {
         groupId = 'org.spekframework.spek2'
         artifactId = artifactName
         version = rootProject.version
 
         from project.components.java
+        
         artifact project.tasks['sourceJar']
         artifact project.tasks['javadocJar']
-
+        
         pom.withXml {
             asNode().children().last() + {
                 resolveStrategy =  DELEGATE_FIRST
@@ -44,6 +45,29 @@ def artifact(publication, project, artifactName) {
                     url 'http://github.com/spekframework/spek'
                 }
             }
+            
+            
+            // Because of tree-like structure of the project Gradle screws up groupId and artifactId of cross-module deps.
+            // ie         `<dependency><groupId>spek.spek-runtime</groupId><artifactId>jvm</artifactId></dependency>`
+            // instead of `<dependency><groupId>org.spekframework.spek2</groupId><artifactId>spek-runtime-jvm</artifactId></dependency>`
+            // So we traverse dependencies in generated pom and fix them.
+            asNode()
+                    .dependencies
+                    .dependency
+                    .findAll { dep -> dep.groupId.get(0).text().startsWith("${rootProject.name}") } // ie 'spek.'
+                    .collect { dep -> 
+                        Node groupIdNode = dep.groupId.get(0)
+                        Node artifactIdNode = dep.artifactId.get(0)
+                        
+                        String originalGroupId = groupIdNode.text()
+                        String originalArtifactId = artifactIdNode.text()
+                
+                        String fixedArtifactId = originalGroupId
+                                .substring(originalGroupId.indexOf('.') + 1, originalGroupId.length()) + '-' + originalArtifactId
+                
+                        groupIdNode.setValue(groupId)
+                        artifactIdNode.setValue(fixedArtifactId)
+                    } 
         }
     }
 

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -17,7 +17,7 @@ def artifact(Publication publication, Project project, artifactName) {
         
         artifact project.tasks['sourceJar']
         artifact project.tasks['javadocJar']
-        
+
         pom.withXml {
             asNode().children().last() + {
                 resolveStrategy =  DELEGATE_FIRST


### PR DESCRIPTION
This PR fixes #317.

Previously Gradle screwed up our cross-module dependencies in generated pom:

```xml
<dependency>
  <groupId>spek.spek-runtime</groupId>
  <artifactId>jvm</artifactId>
  <version>1.1.5</version>
  <scope>compile</scope>
</dependency>
```

After fix in this PR:

```xml
<dependency>
  <groupId>org.spekframework.spek2</groupId>
  <artifactId>spek-dsl-jvm</artifactId>
  <version>1.1.5</version>
  <scope>compile</scope>
</dependency>
```

I've tried different ways to fix it, but nothing worked as planned so I ended up just rewriting pom xml.

Thanks Gradle

![me](https://user-images.githubusercontent.com/967132/33824614-d9333e0c-de13-11e7-8727-8111a4e728d6.jpg)
