### PR TITLE
Fix rendering of generics in docs

### DIFF
--- a/documentation/src/asciidoc/setting-up.adoc
+++ b/documentation/src/asciidoc/setting-up.adoc
@@ -10,7 +10,7 @@ NOTE: For Android projects check <<setting-up-legacy>> section.
 === Gradle
 JUnit Platform provides a http://junit.org/junit5/docs/current/user-guide/#running-tests-build[gradle plugin].
 
-[source,groovy,subs="attributes"]
+[source,groovy,subs="+attributes"]
 .build.gradle
 ----
 // setup the plugin
@@ -42,7 +42,7 @@ dependencies {
 ----
 
 === Gradle Kotlin Script
-[source,kotlin,subs="attributes"]
+[source,kotlin,subs="+attributes"]
 .build.gradle.kts
 ----
 import org.gradle.api.plugins.ExtensionAware
@@ -95,7 +95,7 @@ fun FiltersExtension.engines(setup: EnginesExtension.() -> Unit) {
 If you are using a version of Kotlin that is different than the one used by Spek, you will want to exclude
 the group in your dependency definition.
 
-[source,groovy,subs="attributes"]
+[source,groovy,subs="+attributes"]
 .build.gradle
 ----
 dependencies {
@@ -150,5 +150,3 @@ class CalculatorSpec: Spek({
 ----
 
 IMPORTANT: As mentioned in the <<ide-support>> section, the IDEA plugin won't work if you're using the JUnit 4 runner.
-
-


### PR DESCRIPTION
When using `subs="attributes"`, asciidoctor doesn't do what is needed. It needs to be either `subs="+attributes"` or `subs="attributes+"`.

This does the former.

Fixes #361