### PR TITLE
Narrow down spec discovery

### DIFF
--- a/spek-ide-plugin/interop-common/src/main/kotlin/org/spekframework/ide/console.kt
+++ b/spek-ide-plugin/interop-common/src/main/kotlin/org/spekframework/ide/console.kt
@@ -67,7 +67,7 @@ abstract class AbstractSpek2ConsoleLauncher: ConsoleLauncher {
     private val runtime = SpekRuntime()
 
     protected fun execute(path: Path, listeners: List<ExecutionListener>) {
-        val discoveryResult = runtime.discover(DiscoveryRequest(path))
+        val discoveryResult = runtime.discover(DiscoveryRequest(path, emptyList()))
         runtime.execute(ExecutionRequest(discoveryResult.roots, Spek2CompoundRuntimeExecutionListener(listeners)))
     }
 }

--- a/spek-ide-plugin/interop-common/src/main/kotlin/org/spekframework/ide/console.kt
+++ b/spek-ide-plugin/interop-common/src/main/kotlin/org/spekframework/ide/console.kt
@@ -67,7 +67,7 @@ abstract class AbstractSpek2ConsoleLauncher: ConsoleLauncher {
     private val runtime = SpekRuntime()
 
     protected fun execute(path: Path, listeners: List<ExecutionListener>) {
-        val discoveryResult = runtime.discover(DiscoveryRequest(path, emptyList()))
+        val discoveryResult = runtime.discover(DiscoveryRequest(emptyList(), path))
         runtime.execute(ExecutionRequest(discoveryResult.roots, Spek2CompoundRuntimeExecutionListener(listeners)))
     }
 }

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
@@ -23,7 +23,7 @@ class SpekTestEngine: TestEngine {
         val pathSelector = discoveryRequest.getSelectorsByType(PathSelector::class.java)
             .firstOrNull() ?: PathSelector(PathBuilder.ROOT)
 
-        val discoveryResult = runtime.discover(DiscoveryRequest(pathSelector.path))
+        val discoveryResult = runtime.discover(DiscoveryRequest(pathSelector.path, emptyList()))
 
         discoveryResult.roots
             .map(this::toTestDescriptor)

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
@@ -23,7 +23,7 @@ class SpekTestEngine: TestEngine {
         val pathSelector = discoveryRequest.getSelectorsByType(PathSelector::class.java)
             .firstOrNull() ?: PathSelector(PathBuilder.ROOT)
 
-        val discoveryResult = runtime.discover(DiscoveryRequest(pathSelector.path, emptyList()))
+        val discoveryResult = runtime.discover(DiscoveryRequest(emptyList(), pathSelector.path))
 
         discoveryResult.roots
             .map(this::toTestDescriptor)

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/execution/Discovery.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/execution/Discovery.kt
@@ -3,6 +3,6 @@ package org.spekframework.spek2.runtime.execution
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.scope.ScopeImpl
 
-data class DiscoveryRequest(val path: Path, val sourceDirs: List<String>)
+data class DiscoveryRequest(val path: Path, val specDirs: List<String>)
 data class DiscoveryResult(val roots: List<ScopeImpl>)
 

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/execution/Discovery.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/execution/Discovery.kt
@@ -3,6 +3,6 @@ package org.spekframework.spek2.runtime.execution
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.scope.ScopeImpl
 
-data class DiscoveryRequest(val path: Path, val specDirs: List<String>)
+data class DiscoveryRequest(val sourceDirs: List<String>, val path: Path)
 data class DiscoveryResult(val roots: List<ScopeImpl>)
 

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/execution/Discovery.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/execution/Discovery.kt
@@ -3,6 +3,6 @@ package org.spekframework.spek2.runtime.execution
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.scope.ScopeImpl
 
-data class DiscoveryRequest(val path: Path)
+data class DiscoveryRequest(val path: Path, val sourceDirs: List<String>)
 data class DiscoveryResult(val roots: List<ScopeImpl>)
 

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/test/AbstractSpekRuntimeTest.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/test/AbstractSpekRuntimeTest.kt
@@ -18,7 +18,7 @@ abstract class AbstractSpekRuntimeTest {
 
     protected fun executeTestsforPath(path: Path): ExecutionEventRecorder {
         return ExecutionEventRecorder().apply {
-            val discoveryRequest = DiscoveryRequest(path, emptyList())
+            val discoveryRequest = DiscoveryRequest(emptyList(), path)
             val discoveryResult = runtime.discover(discoveryRequest)
             val executionRequest = ExecutionRequest(discoveryResult.roots, this)
             runtime.execute(executionRequest)

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/test/AbstractSpekRuntimeTest.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/test/AbstractSpekRuntimeTest.kt
@@ -18,7 +18,7 @@ abstract class AbstractSpekRuntimeTest {
 
     protected fun executeTestsforPath(path: Path): ExecutionEventRecorder {
         return ExecutionEventRecorder().apply {
-            val discoveryRequest = DiscoveryRequest(path)
+            val discoveryRequest = DiscoveryRequest(path, emptyList())
             val discoveryResult = runtime.discover(discoveryRequest)
             val executionRequest = ExecutionRequest(discoveryResult.roots, this)
             runtime.execute(executionRequest)

--- a/spek-runtime/jvm/src/main/kotlin/org/spekframework/spek2/runtime/SpekJvmRuntime.kt
+++ b/spek-runtime/jvm/src/main/kotlin/org/spekframework/spek2/runtime/SpekJvmRuntime.kt
@@ -26,7 +26,7 @@ actual class SpekRuntime: AbstractRuntime() {
     }
 
     override fun discover(discoveryRequest: DiscoveryRequest): DiscoveryResult {
-        val reflections = createReflections(discoveryRequest.specDirs)
+        val reflections = createReflections(discoveryRequest.sourceDirs)
         val scopes = reflections.getSubTypesOf(Spek::class.java)
             .map(Class<out Spek>::kotlin)
             .filter { it.findAnnotation<Ignore>() == null }

--- a/spek-runtime/jvm/src/main/kotlin/org/spekframework/spek2/runtime/SpekJvmRuntime.kt
+++ b/spek-runtime/jvm/src/main/kotlin/org/spekframework/spek2/runtime/SpekJvmRuntime.kt
@@ -12,6 +12,7 @@ import org.spekframework.spek2.runtime.execution.DiscoveryRequest
 import org.spekframework.spek2.runtime.execution.DiscoveryResult
 import org.spekframework.spek2.runtime.scope.PathBuilder
 import org.spekframework.spek2.runtime.scope.isRelated
+import java.io.File
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
@@ -25,7 +26,7 @@ actual class SpekRuntime: AbstractRuntime() {
     }
 
     override fun discover(discoveryRequest: DiscoveryRequest): DiscoveryResult {
-        val reflections = createReflections(discoveryRequest.sourceDirs)
+        val reflections = createReflections(discoveryRequest.specDirs)
         val scopes = reflections.getSubTypesOf(Spek::class.java)
             .map(Class<out Spek>::kotlin)
             .filter { it.findAnnotation<Ignore>() == null }
@@ -57,8 +58,8 @@ actual class SpekRuntime: AbstractRuntime() {
         val urls = if (testDirs.isEmpty()) {
             ClasspathHelper.forClassLoader()
         } else {
-            testDirs.map { java.nio.file.Paths.get(it) }
-                .map { it.toUri().toURL() }
+            testDirs.map(::File)
+                .map { it.toURI().toURL() }
         }
 
         return Reflections(


### PR DESCRIPTION
This an attempt to solve #328. Introduced `sourceDirs` during discovery which will be used to build up `Reflections`, if empty it will re-use the current class loader's classpath.