### PR TITLE
Pass classpath roots to runtime

### DIFF
--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
@@ -4,11 +4,13 @@ import org.junit.platform.engine.EngineDiscoveryRequest
 import org.junit.platform.engine.TestDescriptor
 import org.junit.platform.engine.TestEngine
 import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.discovery.ClasspathRootSelector
 import org.spekframework.spek2.runtime.SpekRuntime
 import org.spekframework.spek2.runtime.execution.DiscoveryRequest
 import org.spekframework.spek2.runtime.execution.ExecutionRequest
 import org.spekframework.spek2.runtime.scope.PathBuilder
 import org.spekframework.spek2.runtime.scope.ScopeImpl
+import java.nio.file.Paths
 import org.junit.platform.engine.ExecutionRequest as JUnitExecutionRequest
 
 class SpekTestEngine: TestEngine {
@@ -20,10 +22,15 @@ class SpekTestEngine: TestEngine {
     override fun discover(discoveryRequest: EngineDiscoveryRequest, uniqueId: UniqueId): TestDescriptor {
         val engineDescriptor = SpekEngineDescriptor(uniqueId, id)
 
+        val sourceDirs = discoveryRequest.getSelectorsByType(ClasspathRootSelector::class.java)
+            .map { it.classpathRoot }
+            .map { Paths.get(it) }
+            .map { it.toString() }
+
         val pathSelector = discoveryRequest.getSelectorsByType(PathSelector::class.java)
             .firstOrNull() ?: PathSelector(PathBuilder.ROOT)
 
-        val discoveryResult = runtime.discover(DiscoveryRequest(emptyList(), listOf(pathSelector.path)))
+        val discoveryResult = runtime.discover(DiscoveryRequest(sourceDirs, listOf(pathSelector.path)))
 
         discoveryResult.roots
             .map(this::toTestDescriptor)


### PR DESCRIPTION
This takes advantage of #377, to narrow down spec discovery when using the junit5 runner.