### PR TITLE
Memoized supports nullable values

### DIFF
--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/LifecycleAwareAdapter.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/LifecycleAwareAdapter.kt
@@ -10,28 +10,29 @@ import kotlin.reflect.KProperty
 sealed class LifecycleAwareAdapter<T>(val factory: () -> T, val destructor: (T) -> Unit)
     : LifecycleAware<T>, LifecycleListener {
 
-    protected sealed class Cached {
-        object Empty : Cached()
-        data class Value<out T>(val value: T) : Cached()
+    protected sealed class Cached<out T> {
+        object Empty : Cached<Nothing>()
+        data class Value<out T>(val value: T) : Cached<T>()
     }
 
-    protected fun <T> Cached.reified() = this as Cached.Value<T>
-
-    protected var cached: Cached = Cached.Empty
+    protected var cached: Cached<T> = Cached.Empty
 
     override fun getValue(thisRef: Any?, property: KProperty<*>) = invoke()
 
     override fun invoke(): T = when(cached) {
         Cached.Empty -> {
-            cached = Cached.Value(factory())
-            cached.reified<T>().value
+            val newCached = Cached.Value(factory())
+            cached = newCached
+            newCached.value
         }
-        is Cached.Value<*> -> cached.reified<T>().value
+        is Cached.Value<T> -> cached.cast().value
     }
+
+    protected fun Cached<T>.cast() = cached as Cached.Value<T>
 
     class GroupCachingModeAdapter<T>(factory: () -> T, destructor: (T) -> Unit)
         : LifecycleAwareAdapter<T>(factory, destructor) {
-        private val stack = mutableListOf<Cached>()
+        private val stack = mutableListOf<Cached<T>>()
 
         override fun beforeExecuteGroup(group: GroupScope) {
             stack.add(0, cached)
@@ -39,8 +40,8 @@ sealed class LifecycleAwareAdapter<T>(val factory: () -> T, val destructor: (T) 
         }
 
         override fun afterExecuteGroup(group: GroupScope) {
-            if (cached != Cached.Empty) {
-                destructor(cached.reified<T>().value)
+            if (cached is Cached.Value<T>) {
+                destructor(cached.cast().value)
             }
             if (stack.isNotEmpty()) {
                 cached = stack.removeAt(0)
@@ -52,8 +53,8 @@ sealed class LifecycleAwareAdapter<T>(val factory: () -> T, val destructor: (T) 
         : LifecycleAwareAdapter<T>(factory, destructor) {
         override fun afterExecuteGroup(group: GroupScope) {
             if (this.group == group) {
-                if (cached != Cached.Empty) {
-                    destructor(cached.reified<T>().value)
+                when (cached) {
+                    is Cached.Value<T> -> destructor(cached.cast().value)
                 }
                 cached = Cached.Empty
             }
@@ -64,16 +65,16 @@ sealed class LifecycleAwareAdapter<T>(val factory: () -> T, val destructor: (T) 
         : LifecycleAwareAdapter<T>(factory, destructor) {
         override fun afterExecuteTest(test: TestScope) {
             if (test.parent !is ActionScope) {
-                if (cached != Cached.Empty) {
-                    destructor(cached.reified<T>().value)
+                when (cached) {
+                    is Cached.Value<T> -> destructor(cached.cast().value)
                 }
                 cached = Cached.Empty
             }
         }
 
         override fun afterExecuteAction(action: ActionScope) {
-            if (cached != Cached.Empty) {
-                destructor(cached.reified<T>().value)
+            when (cached) {
+                is Cached.Value<T> -> destructor(cached.cast().value)
             }
             cached = Cached.Empty
         }

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/LifecycleAwareAdapter.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/LifecycleAwareAdapter.kt
@@ -21,7 +21,7 @@ sealed class LifecycleAwareAdapter<T>(val factory: () -> T, val destructor: (T) 
 
     override fun invoke(): T {
         val cached = this.cached
-        when(cached) {
+        return when(cached) {
             Cached.Empty -> {
                 val newCached = Cached.Value(factory())
                 this.cached = newCached

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/LifecycleAwareAdapter.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/LifecycleAwareAdapter.kt
@@ -28,7 +28,7 @@ sealed class LifecycleAwareAdapter<T>(val factory: () -> T, val destructor: (T) 
         is Cached.Value<T> -> cached.cast().value
     }
 
-    protected fun Cached<T>.cast() = cached as Cached.Value<T>
+    protected fun Cached<T>.cast() = this as Cached.Value<T>
 
     class GroupCachingModeAdapter<T>(factory: () -> T, destructor: (T) -> Unit)
         : LifecycleAwareAdapter<T>(factory, destructor) {

--- a/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/MemoizedTest.kt
+++ b/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/MemoizedTest.kt
@@ -396,4 +396,20 @@ class MemoizedTest : AbstractSpekRuntimeTest() {
 
         assertThat(recorder.testFailureCount, equalTo(0))
     }
+
+    @Test
+    fun memoizedWithNullValue() {
+        class MemoizedSpec : Spek({
+
+            val foo by memoized { null }
+
+            test("check") {
+                assertThat(foo, equalTo(null))
+            }
+        })
+
+        val recorder = executeTestsForClass(MemoizedSpec::class)
+
+        assertThat(recorder.testFailureCount, equalTo(0))
+    }
 }


### PR DESCRIPTION
Fixes - #217 

Resorted to using a wrapper for the cached value.

Other explored routes :
- `lateinit var` does not work because it is not allowed to be nullable
- adding a boolean to check caching instead of comparing to null value does not work because we cannot declare cached property as `T` and initialize it to `null`