### PR TITLE
[FIX 1.x] Spek without default constructor

### DIFF
--- a/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
+++ b/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekTestEngine.kt
@@ -58,7 +58,7 @@ class SpekTestEngine: HierarchicalTestEngine<SpekExecutionContext>() {
 
     private fun resolveSpecs(discoveryRequest: EngineDiscoveryRequest, engineDescriptor: EngineDescriptor) {
         val isValidSpec = java.util.function.Predicate<Class<*>> {
-            Spek::class.java.isAssignableFrom(it) && !Modifier.isAbstract(it.modifiers)
+            Spek::class.java.isAssignableFrom(it) && !Modifier.isAbstract(it.modifiers) && it.constructors.any { it.parameters.isEmpty() }
         }
 
         val isSpecClass = java.util.function.Predicate<String>(String::isNotEmpty)

--- a/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/InvalidSpekTest.kt
+++ b/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/InvalidSpekTest.kt
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.Test
 /**
  * @author Ranie Jade Ramiso
  */
-class AbstractSpekTest: AbstractSpekTestEngineTest() {
+class InvalidSpekTest: AbstractSpekTestEngineTest() {
+
     @Test
-    fun testIgnoreAbstractClass() {
-        val recorder = executeForPackage("org.jetbrains.spek.engine.packageWithAbstractSpek")
+    fun testIgnoreInvalidSpek() {
+        val recorder = executeForPackage("org.jetbrains.spek.engine.packageWithInvalidSpek")
         assertThat(recorder.testStartedCount, equalTo(0))
     }
+
 }

--- a/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/packageWithInvalidSpek/NonDefaultConstructorSpek.kt
+++ b/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/packageWithInvalidSpek/NonDefaultConstructorSpek.kt
@@ -1,0 +1,7 @@
+package org.jetbrains.spek.engine.packageWithInvalidSpek
+
+import org.jetbrains.spek.api.Spek
+
+
+class NonDefaultConstructorSpek(name: String) : Spek({
+})

--- a/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/packageWithInvalidSpek/SomeAbstractSpek.kt
+++ b/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/packageWithInvalidSpek/SomeAbstractSpek.kt
@@ -1,5 +1,5 @@
 /* Don't add anything in this package - [org.jetbrains.spek.engine.AbstractSpekTest] will fail. */
-package org.jetbrains.spek.engine.packageWithAbstractSpek
+package org.jetbrains.spek.engine.packageWithInvalidSpek
 
 import org.jetbrains.spek.api.Spek
 


### PR DESCRIPTION
Hi,

For a generic setup we use a spek class without a default constructor
```kotlin
class Foo<T>(val bar: Any) : Spek({
    beforeEachTest {
        bar.startSomething()
    }

    afterEachTest {
        bar.finishSomething()
    }
})
```
And then use it like this
```kotlin
object MySpek : Spek({

    include(Foo(bar))

    ...

})
```
I am not sur this is the good way to generify some setup accros a lot of spek ?
By the way the `SpekTestEngine` will crash when it will try to create the spek test instance.

On this pull request a spek should have a default constructor.
I think it's not what we want because we can use `org.jetbrains.spek.api.CreateWith` annotation to let the `SpekTestEngine` know how to instantiate the spek (without a default constructor).
To be more robust I think we could change the `InstanceFactory` and let `create` method return a nullable.
```
interface InstanceFactory {
    fun <T: Spek> create(spek: KClass<T>): T?
}
```
Then the `defaultInstanceFactory` will return null if the spek don't have a default constructor.
At the end we just need to check if the spek instance is null before `invoke` it.

If you would like the second option just tell me I will update my pull request.

Best