### PR TITLE
Rework DSL implicit receiver names and use @DslMarker

### DIFF
--- a/samples/src/test/kotlin/org/spekframework/spek2/samples/subject/AdvancedCalculatorSpec.kt
+++ b/samples/src/test/kotlin/org/spekframework/spek2/samples/subject/AdvancedCalculatorSpec.kt
@@ -6,7 +6,7 @@ import org.spekframework.spek2.subject.itBehavesLike
 import kotlin.test.assertEquals
 
 object AdvancedCalculatorSpec: SubjectSpek<AdvancedCalculator>({
-    subject { AdvancedCalculator() }
+    val subject by subject { AdvancedCalculator() }
     itBehavesLike(CalculatorSpec)
 
     describe("pow") {

--- a/samples/src/test/kotlin/org/spekframework/spek2/samples/subject/CalculatorSpec.kt
+++ b/samples/src/test/kotlin/org/spekframework/spek2/samples/subject/CalculatorSpec.kt
@@ -7,7 +7,7 @@ import org.spekframework.spek2.subject.SubjectSpek
 import kotlin.test.assertEquals
 
 object CalculatorSpec: SubjectSpek<Calculator>({
-    subject { Calculator() }
+    val subject by subject { Calculator() }
 
     describe("addition") {
         it("should return the result of adding the first number to the second number") {

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/Shared.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/Shared.kt
@@ -1,12 +1,12 @@
 package org.spekframework.spek2
 
-import org.spekframework.spek2.dsl.Spec
+import org.spekframework.spek2.dsl.Root
 import org.spekframework.spek2.meta.Experimental
 
 /**
  * @since 1.1
  */
 @Experimental
-fun Spec.include(spec: Spek) {
-    spec.spec(this)
+fun Root.include(spec: Spek) {
+    spec.root(this)
 }

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/Spek.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/Spek.kt
@@ -1,12 +1,12 @@
 package org.spekframework.spek2
 
-import org.spekframework.spek2.dsl.Spec
+import org.spekframework.spek2.dsl.Root
 
 /**
  * @since 1.0
  */
-abstract class Spek(val spec: Spec.() -> Unit) {
+abstract class Spek(val root: Root.() -> Unit) {
     companion object {
-        fun wrap(spec: Spec.() -> Unit) = @Ignore object: Spek(spec) {}
+        fun wrap(root: Root.() -> Unit) = @Ignore object : Spek(root) {}
     }
 }

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/ActionBody.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/ActionBody.kt
@@ -3,25 +3,4 @@ package org.spekframework.spek2.dsl
 import org.spekframework.spek2.meta.SpekDsl
 
 @SpekDsl
-interface ActionBody: TestContainer {
-
-    @Deprecated(message = "Can't be used within action scopes", level = DeprecationLevel.ERROR)
-    fun beforeEachTest(callback: () -> Unit) {
-        throw UnsupportedOperationException()
-    }
-
-    @Deprecated(message = "Can't be used within action scopes", level = DeprecationLevel.ERROR)
-    fun afterEachTest(callback: () -> Unit) {
-        throw UnsupportedOperationException()
-    }
-
-    @Deprecated(message = "Can't be used within action scopes", level = DeprecationLevel.ERROR)
-    fun beforeGroup(callback: () -> Unit) {
-        throw UnsupportedOperationException()
-    }
-
-    @Deprecated(message = "Can't be used within action scopes", level = DeprecationLevel.ERROR)
-    fun afterGroup(callback: () -> Unit) {
-        throw UnsupportedOperationException()
-    }
-}
+interface ActionBody: TestContainer

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/GroupBody.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/GroupBody.kt
@@ -10,9 +10,9 @@ import org.spekframework.spek2.meta.SynonymType
  * @since 1.0
  */
 @SpekDsl
-interface SpecBody: TestContainer {
+interface GroupBody: TestContainer {
     @Synonym(type = SynonymType.Group)
-    fun group(description: String, pending: Pending = Pending.No, body: SpecBody.() -> Unit)
+    fun group(description: String, pending: Pending = Pending.No, body: GroupBody.() -> Unit)
 
     @Synonym(type = SynonymType.Action)
     fun action(description: String, pending: Pending = Pending.No, body: ActionBody.() -> Unit)
@@ -27,37 +27,37 @@ interface SpecBody: TestContainer {
     fun afterGroup(callback: () -> Unit)
 
     /**
-     * Creates a [group][SpecBody.group].
+     * Creates a [group][GroupBody.group].
      *
      * @since 1.0
      */
     @Synonym(type = SynonymType.Group, prefix = "describe")
-    fun describe(description: String, body: SpecBody.() -> Unit) {
+    fun describe(description: String, body: GroupBody.() -> Unit) {
         group("describe $description", body = body)
     }
 
     /**
-     * Creates a [group][SpecBody.group].
+     * Creates a [group][GroupBody.group].
      *
      * @since 1.0
      */
     @Synonym(type = SynonymType.Group, prefix = "context")
-    fun context(description: String, body: SpecBody.() -> Unit) {
+    fun context(description: String, body: GroupBody.() -> Unit) {
         group("context $description", body = body)
     }
 
     /**
-     * Creates a [group][SpecBody.group].
+     * Creates a [group][GroupBody.group].
      *
      * @since 1.0
      */
     @Synonym(type = SynonymType.Group, prefix = "given")
-    fun given(description: String, body: SpecBody.() -> Unit) {
+    fun given(description: String, body: GroupBody.() -> Unit) {
         group("given $description", body = body)
     }
 
     /**
-     * Creates an [action][SpecBody.action].
+     * Creates an [action][GroupBody.action].
      *
      * @since 1.0
      */
@@ -67,37 +67,37 @@ interface SpecBody: TestContainer {
     }
 
     /**
-     * Creates a [group][SpecBody.group].
+     * Creates a [group][GroupBody.group].
      *
      * @since 1.0
      */
     @Synonym(type = SynonymType.Group, prefix = "describe", excluded = true)
-    fun xdescribe(description: String, reason: String? = null, body: SpecBody.() -> Unit) {
+    fun xdescribe(description: String, reason: String? = null, body: GroupBody.() -> Unit) {
         group("describe $description", Pending.Yes(reason), body = body)
     }
 
     /**
-     * Creates a [group][SpecBody.group].
+     * Creates a [group][GroupBody.group].
      *
      * @since 1.0
      */
     @Synonym(type = SynonymType.Group, prefix = "context", excluded = true)
-    fun xcontext(description: String, reason: String? = null, body: SpecBody.() -> Unit) {
+    fun xcontext(description: String, reason: String? = null, body: GroupBody.() -> Unit) {
         group("context $description", Pending.Yes(reason), body = body)
     }
 
     /**
-     * Creates a [group][SpecBody.group].
+     * Creates a [group][GroupBody.group].
      *
      * @since 1.0
      */
     @Synonym(type = SynonymType.Group, prefix = "given", excluded = true)
-    fun xgiven(description: String, reason: String? = null, body: SpecBody.() -> Unit) {
+    fun xgiven(description: String, reason: String? = null, body: GroupBody.() -> Unit) {
         group("given $description", Pending.Yes(reason), body = body)
     }
 
     /**
-     * Creates a pending [action][SpecBody.action].
+     * Creates a pending [action][GroupBody.action].
      *
      * @since 1.0
      */

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/Root.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/Root.kt
@@ -2,11 +2,13 @@ package org.spekframework.spek2.dsl
 
 import org.spekframework.spek2.lifecycle.LifecycleListener
 import org.spekframework.spek2.meta.Experimental
+import org.spekframework.spek2.meta.SpekDsl
 
 /**
  * @since 1.1
  */
 @Experimental
-interface Spec: SpecBody {
+@SpekDsl
+interface Root: GroupBody {
     fun registerListener(listener: LifecycleListener)
 }

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/TestContainer.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/TestContainer.kt
@@ -10,7 +10,7 @@ interface TestContainer {
     fun test(description: String, pending: Pending = Pending.No, body: TestBody.() -> Unit)
 
     /**
-     * Creates a [test][SpecBody.test].
+     * Creates a [test][GroupBody.test].
      *
      * @author Ranie Jade Ramiso
      * @since 1.0
@@ -21,7 +21,7 @@ interface TestContainer {
     }
 
     /**
-     * Creates a pending [test][SpecBody.test].
+     * Creates a pending [test][GroupBody.test].
      *
      * @author Ranie Jade Ramiso
      * @since 1.0

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/meta/SpekDsl.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/meta/SpekDsl.kt
@@ -6,4 +6,5 @@ package org.spekframework.spek2.meta
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @Experimental
+@DslMarker
 annotation class SpekDsl

--- a/spek-extension/data-driven/common/src/main/kotlin/org/spekframework/spek2/data_driven/namespace.kt
+++ b/spek-extension/data-driven/common/src/main/kotlin/org/spekframework/spek2/data_driven/namespace.kt
@@ -3,11 +3,11 @@
 package org.spekframework.spek2.data_driven
 
 import org.spekframework.spek2.dsl.ActionBody
-import org.spekframework.spek2.dsl.SpecBody
+import org.spekframework.spek2.dsl.GroupBody
 
 expect fun String.format(vararg args: Any?): String
 
-inline fun <I1, Expected> SpecBody.on(description: String, vararg with: Data1<I1, Expected>, crossinline body: ActionBody.(I1, Expected) -> Unit) {
+inline fun <I1, Expected> GroupBody.on(description: String, vararg with: Data1<I1, Expected>, crossinline body: ActionBody.(I1, Expected) -> Unit) {
     with.forEach { (input, expected) ->
         on(description = description.format(input, expected)) {
             body(input, expected)
@@ -15,7 +15,7 @@ inline fun <I1, Expected> SpecBody.on(description: String, vararg with: Data1<I1
     }
 }
 
-inline fun <I1, I2, Expected> SpecBody.on(description: String, vararg with: Data2<I1, I2, Expected>, crossinline body: ActionBody.(I1, I2, Expected) -> Unit) {
+inline fun <I1, I2, Expected> GroupBody.on(description: String, vararg with: Data2<I1, I2, Expected>, crossinline body: ActionBody.(I1, I2, Expected) -> Unit) {
     with.forEach { (input1, input2, expected) ->
         on(description = description.format(input1, input2, expected)) {
             body(input1, input2, expected)
@@ -23,7 +23,7 @@ inline fun <I1, I2, Expected> SpecBody.on(description: String, vararg with: Data
     }
 }
 
-inline fun <I1, I2, I3, Expected> SpecBody.on(description: String, vararg with: Data3<I1, I2, I3, Expected>, crossinline body: ActionBody.(I1, I2, I3, Expected) -> Unit) {
+inline fun <I1, I2, I3, Expected> GroupBody.on(description: String, vararg with: Data3<I1, I2, I3, Expected>, crossinline body: ActionBody.(I1, I2, I3, Expected) -> Unit) {
     with.forEach { (input1, input2, input3, expected) ->
         on(description = description.format(input1, input2, input3, expected)) {
             body(input1, input2, input3, expected)
@@ -31,7 +31,7 @@ inline fun <I1, I2, I3, Expected> SpecBody.on(description: String, vararg with: 
     }
 }
 
-inline fun <I1, I2, I3, I4, Expected> SpecBody.on(description: String, vararg with: Data4<I1, I2, I3, I4, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, Expected) -> Unit) {
+inline fun <I1, I2, I3, I4, Expected> GroupBody.on(description: String, vararg with: Data4<I1, I2, I3, I4, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, Expected) -> Unit) {
     with.forEach { (input1, input2, input3, input4, expected) ->
         on(description = description.format(input1, input2, input3, input4, expected)) {
             body(input1, input2, input3, input4, expected)
@@ -39,7 +39,7 @@ inline fun <I1, I2, I3, I4, Expected> SpecBody.on(description: String, vararg wi
     }
 }
 
-inline fun <I1, I2, I3, I4, I5, Expected> SpecBody.on(description: String, vararg with: Data5<I1, I2, I3, I4, I5, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, Expected) -> Unit) {
+inline fun <I1, I2, I3, I4, I5, Expected> GroupBody.on(description: String, vararg with: Data5<I1, I2, I3, I4, I5, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, Expected) -> Unit) {
     with.forEach { (input1, input2, input3, input4, input5, expected) ->
         on(description = description.format(input1, input2, input3, input4, input5, expected)) {
             body(input1, input2, input3, input4, input5, expected)
@@ -47,7 +47,7 @@ inline fun <I1, I2, I3, I4, I5, Expected> SpecBody.on(description: String, varar
     }
 }
 
-inline fun <I1, I2, I3, I4, I5, I6, Expected> SpecBody.on(description: String, vararg with: Data6<I1, I2, I3, I4, I5, I6, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, I6, Expected) -> Unit) {
+inline fun <I1, I2, I3, I4, I5, I6, Expected> GroupBody.on(description: String, vararg with: Data6<I1, I2, I3, I4, I5, I6, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, I6, Expected) -> Unit) {
     with.forEach { (input1, input2, input3, input4, input5, input6, expected) ->
         on(description = description.format(input1, input2, input3, input4, input5, input6, expected)) {
             body(input1, input2, input3, input4, input5, input6, expected)
@@ -55,7 +55,7 @@ inline fun <I1, I2, I3, I4, I5, I6, Expected> SpecBody.on(description: String, v
     }
 }
 
-inline fun <I1, I2, I3, I4, I5, I6, I7, Expected> SpecBody.on(description: String, vararg with: Data7<I1, I2, I3, I4, I5, I6, I7, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, I6, I7, Expected) -> Unit) {
+inline fun <I1, I2, I3, I4, I5, I6, I7, Expected> GroupBody.on(description: String, vararg with: Data7<I1, I2, I3, I4, I5, I6, I7, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, I6, I7, Expected) -> Unit) {
     with.forEach { (input1, input2, input3, input4, input5, input6, input7, expected) ->
         on(description = description.format(input1, input2, input3, input4, input5, input6, input7, expected)) {
             body(input1, input2, input3, input4, input5, input6, input7, expected)
@@ -63,7 +63,7 @@ inline fun <I1, I2, I3, I4, I5, I6, I7, Expected> SpecBody.on(description: Strin
     }
 }
 
-inline fun <I1, I2, I3, I4, I5, I6, I7, I8, Expected> SpecBody.on(description: String, vararg with: Data8<I1, I2, I3, I4, I5, I6, I7, I8, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, I6, I7, I8, Expected) -> Unit) {
+inline fun <I1, I2, I3, I4, I5, I6, I7, I8, Expected> GroupBody.on(description: String, vararg with: Data8<I1, I2, I3, I4, I5, I6, I7, I8, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, I6, I7, I8, Expected) -> Unit) {
     with.forEach { (input1, input2, input3, input4, input5, input6, input7, input8, expected) ->
         on(description = description.format(input1, input2, input3, input4, input5, input6, input7, input8, expected)) {
             body(input1, input2, input3, input4, input5, input6, input7, input8, expected)
@@ -71,7 +71,7 @@ inline fun <I1, I2, I3, I4, I5, I6, I7, I8, Expected> SpecBody.on(description: S
     }
 }
 
-inline fun <I1, I2, I3, I4, I5, I6, I7, I8, I9, Expected> SpecBody.on(description: String, vararg with: Data9<I1, I2, I3, I4, I5, I6, I7, I8, I9, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, I6, I7, I8, I9, Expected) -> Unit) {
+inline fun <I1, I2, I3, I4, I5, I6, I7, I8, I9, Expected> GroupBody.on(description: String, vararg with: Data9<I1, I2, I3, I4, I5, I6, I7, I8, I9, Expected>, crossinline body: ActionBody.(I1, I2, I3, I4, I5, I6, I7, I8, I9, Expected) -> Unit) {
     with.forEach { (input1, input2, input3, input4, input5, input6, input7, input8, input9, expected) ->
         on(description = description.format(input1, input2, input3, input4, input5, input6, input7, input8, input9, expected)) {
             body(input1, input2, input3, input4, input5, input6, input7, input8, input9, expected)

--- a/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/Shared.kt
+++ b/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/Shared.kt
@@ -1,7 +1,7 @@
 package org.spekframework.spek2.subject
 
 import org.spekframework.spek2.Spek
-import org.spekframework.spek2.dsl.Spec
+import org.spekframework.spek2.dsl.Root
 import org.spekframework.spek2.include
 import org.spekframework.spek2.lifecycle.CachingMode
 import org.spekframework.spek2.lifecycle.LifecycleAware
@@ -10,7 +10,7 @@ import org.spekframework.spek2.subject.dsl.SubjectDsl
 import org.spekframework.spek2.subject.dsl.SubjectProviderDsl
 import kotlin.reflect.KProperty
 
-internal class IncludedSubjectSpek<T>(val adapter: LifecycleAware<T>, spec: Spec): SubjectProviderDsl<T>, Spec by spec {
+internal class IncludedSubjectSpek<T>(val adapter: LifecycleAware<T>, root: Root): SubjectProviderDsl<T>, Root by root {
     override fun subject() = adapter
     override fun subject(mode: CachingMode, factory: () -> T): LifecycleAware<T> {
         return adapter
@@ -32,7 +32,7 @@ infix fun <T, K: T> SubjectDsl<K>.itBehavesLike(spec: SubjectSpek<T>) {
             }
 
         }
-        spec.spec.invoke(IncludedSubjectSpek(adapter, this))
+        spec.root.invoke(IncludedSubjectSpek(adapter, this))
     })
 
 }

--- a/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/core/SubjectDslImpl.kt
+++ b/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/core/SubjectDslImpl.kt
@@ -1,6 +1,6 @@
 package org.spekframework.spek2.subject.core
 
-import org.spekframework.spek2.dsl.Spec
+import org.spekframework.spek2.dsl.Root
 import org.spekframework.spek2.subject.dsl.SubjectDsl
 
-internal abstract class SubjectDslImpl<T>(val root: Spec): SubjectDsl<T>, Spec by root
+internal abstract class SubjectDslImpl<T>(val root: Root): SubjectDsl<T>, Root by root

--- a/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/core/SubjectProviderDslImpl.kt
+++ b/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/core/SubjectProviderDslImpl.kt
@@ -1,12 +1,12 @@
 package org.spekframework.spek2.subject.core
 
-import org.spekframework.spek2.dsl.Spec
+import org.spekframework.spek2.dsl.Root
 import org.spekframework.spek2.lifecycle.CachingMode
 import org.spekframework.spek2.lifecycle.LifecycleAware
 import org.spekframework.spek2.subject.dsl.SubjectProviderDsl
 import kotlin.properties.Delegates
 
-internal class SubjectProviderDslImpl<T>(spec: Spec): SubjectDslImpl<T>(spec), SubjectProviderDsl<T> {
+internal class SubjectProviderDslImpl<T>(root: Root): SubjectDslImpl<T>(root), SubjectProviderDsl<T> {
     var adapter: LifecycleAware<T> by Delegates.notNull()
     override val subject: T
         get() = adapter()

--- a/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/dsl/SubjectDsl.kt
+++ b/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/dsl/SubjectDsl.kt
@@ -6,6 +6,7 @@ import org.spekframework.spek2.meta.Experimental
 
 @Experimental
 interface SubjectDsl<T>: Root {
+    @Deprecated("Use returned value, e.g val subject by subject { ... }")
     val subject: T
 
     fun subject(): LifecycleAware<T>

--- a/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/dsl/SubjectDsl.kt
+++ b/spek-extension/subject/common/src/main/kotlin/org/spekframework/spek2/subject/dsl/SubjectDsl.kt
@@ -1,11 +1,11 @@
 package org.spekframework.spek2.subject.dsl
 
-import org.spekframework.spek2.dsl.Spec
+import org.spekframework.spek2.dsl.Root
 import org.spekframework.spek2.lifecycle.LifecycleAware
 import org.spekframework.spek2.meta.Experimental
 
 @Experimental
-interface SubjectDsl<T>: Spec {
+interface SubjectDsl<T>: Root {
     val subject: T
 
     fun subject(): LifecycleAware<T>

--- a/spek-extension/subject/jvm/src/test/kotlin/org/spekframework/spek2/subject/IncludeSubjectTest.kt
+++ b/spek-extension/subject/jvm/src/test/kotlin/org/spekframework/spek2/subject/IncludeSubjectTest.kt
@@ -13,7 +13,7 @@ class IncludeSubjectTest: AbstractSpekRuntimeTest() {
     @Test
     fun itShouldOverrideNestedSubject() {
         class JavaQueueSpec : SubjectSpek<Queue<String>>({
-            subject {
+            val subject by subject {
                 LinkedList()
             }
 

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/Collectors.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/Collectors.kt
@@ -2,8 +2,8 @@ package org.spekframework.spek2.runtime
 
 import org.spekframework.spek2.dsl.ActionBody
 import org.spekframework.spek2.dsl.Pending
-import org.spekframework.spek2.dsl.Spec
-import org.spekframework.spek2.dsl.SpecBody
+import org.spekframework.spek2.dsl.Root
+import org.spekframework.spek2.dsl.GroupBody
 import org.spekframework.spek2.dsl.TestBody
 import org.spekframework.spek2.lifecycle.CachingMode
 import org.spekframework.spek2.lifecycle.LifecycleAware
@@ -20,7 +20,7 @@ import org.spekframework.spek2.runtime.scope.TestScopeImpl
 
 open class Collector(val root: GroupScopeImpl,
                      val lifecycleManager: LifecycleManager,
-                     val fixtures: FixturesAdapter): Spec {
+                     val fixtures: FixturesAdapter): Root {
     val ids = mutableMapOf<String, Int>()
 
     override fun <T> memoized(mode: CachingMode, factory: () -> T): LifecycleAware<T> = memoized(mode, factory) { }
@@ -41,7 +41,7 @@ open class Collector(val root: GroupScopeImpl,
         lifecycleManager.addListener(listener)
     }
 
-    override fun group(description: String, pending: Pending, body: SpecBody.() -> Unit) {
+    override fun group(description: String, pending: Pending, body: GroupBody.() -> Unit) {
         val group = GroupScopeImpl(
             idFor(description),
             root.path.resolve(description),

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
@@ -23,7 +23,7 @@ abstract class AbstractRuntime {
 
         val qualifiedName = (path.parent?.name ?: "") + ".${path.name}"
         val classScope = GroupScopeImpl(ScopeId(ScopeType.CLASS, qualifiedName), path, null, Pending.No, lifecycleManager)
-        instance.spec.invoke(Collector(classScope, lifecycleManager, fixtures))
+        instance.root.invoke(Collector(classScope, lifecycleManager, fixtures))
 
         return classScope
     }


### PR DESCRIPTION
This PR does two things:
- Make DSL implicit receiver names more consistent: `Spec` -> `Root`, `SpecBody` -> `GroupBody`.
- Use `@DslMarker`, resolves #331 and prevents unwanted nesting. Spek requires at least Kotlin `1.1` at this point.