### PR TITLE
Make description building smarter

### DIFF
--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/GroupBody.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/GroupBody.kt
@@ -2,19 +2,19 @@ package org.spekframework.spek2.dsl
 
 import org.spekframework.spek2.lifecycle.CachingMode
 import org.spekframework.spek2.lifecycle.LifecycleAware
-import org.spekframework.spek2.meta.SpekDsl
-import org.spekframework.spek2.meta.Synonym
-import org.spekframework.spek2.meta.SynonymType
+import org.spekframework.spek2.meta.*
 
 /**
  * @since 1.0
  */
 @SpekDsl
 interface GroupBody: TestContainer {
-    @Synonym(type = SynonymType.Group)
+    @Synonym(type = SynonymType.GROUP)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun group(description: String, pending: Pending = Pending.No, body: GroupBody.() -> Unit)
 
-    @Synonym(type = SynonymType.Action)
+    @Synonym(type = SynonymType.ACTION)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun action(description: String, pending: Pending = Pending.No, body: ActionBody.() -> Unit)
 
     fun <T> memoized(mode: CachingMode = CachingMode.TEST, factory: () -> T): LifecycleAware<T>
@@ -31,7 +31,8 @@ interface GroupBody: TestContainer {
      *
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Group, prefix = "describe")
+    @Synonym(type = SynonymType.GROUP, prefix = "describe")
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun describe(description: String, body: GroupBody.() -> Unit) {
         group("describe $description", body = body)
     }
@@ -41,7 +42,8 @@ interface GroupBody: TestContainer {
      *
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Group, prefix = "context")
+    @Synonym(type = SynonymType.GROUP, prefix = "context")
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun context(description: String, body: GroupBody.() -> Unit) {
         group("context $description", body = body)
     }
@@ -51,7 +53,9 @@ interface GroupBody: TestContainer {
      *
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Group, prefix = "given")
+
+    @Synonym(type = SynonymType.GROUP, prefix = "given")
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun given(description: String, body: GroupBody.() -> Unit) {
         group("given $description", body = body)
     }
@@ -61,7 +65,8 @@ interface GroupBody: TestContainer {
      *
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Action, prefix = "on")
+    @Synonym(type = SynonymType.ACTION, prefix = "on")
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun on(description: String, body: ActionBody.() -> Unit) {
         action("on $description", body = body)
     }
@@ -71,7 +76,8 @@ interface GroupBody: TestContainer {
      *
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Group, prefix = "describe", excluded = true)
+    @Synonym(type = SynonymType.GROUP, prefix = "describe", excluded = true)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun xdescribe(description: String, reason: String? = null, body: GroupBody.() -> Unit) {
         group("describe $description", Pending.Yes(reason), body = body)
     }
@@ -81,7 +87,8 @@ interface GroupBody: TestContainer {
      *
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Group, prefix = "context", excluded = true)
+    @Synonym(type = SynonymType.GROUP, prefix = "context", excluded = true)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun xcontext(description: String, reason: String? = null, body: GroupBody.() -> Unit) {
         group("context $description", Pending.Yes(reason), body = body)
     }
@@ -91,7 +98,8 @@ interface GroupBody: TestContainer {
      *
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Group, prefix = "given", excluded = true)
+    @Synonym(type = SynonymType.GROUP, prefix = "given", excluded = true)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun xgiven(description: String, reason: String? = null, body: GroupBody.() -> Unit) {
         group("given $description", Pending.Yes(reason), body = body)
     }
@@ -101,7 +109,8 @@ interface GroupBody: TestContainer {
      *
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Action, prefix = "on", excluded = true)
+    @Synonym(type = SynonymType.ACTION, prefix = "on", excluded = true)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun xon(description: String, reason: String? = null, body: ActionBody.() -> Unit = {}) {
         action("on $description", Pending.Yes(reason), body = body)
     }

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/TestContainer.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/TestContainer.kt
@@ -1,12 +1,11 @@
 package org.spekframework.spek2.dsl
 
-import org.spekframework.spek2.meta.SpekDsl
-import org.spekframework.spek2.meta.Synonym
-import org.spekframework.spek2.meta.SynonymType
+import org.spekframework.spek2.meta.*
 
 @SpekDsl
 interface TestContainer {
-    @Synonym(type = SynonymType.Test)
+    @Synonym(type = SynonymType.TEST)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun test(description: String, pending: Pending = Pending.No, body: TestBody.() -> Unit)
 
     /**
@@ -15,7 +14,8 @@ interface TestContainer {
      * @author Ranie Jade Ramiso
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Test, prefix = "it")
+    @Synonym(type = SynonymType.TEST, prefix = "it")
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun it(description: String, body: TestBody.() -> Unit) {
         test("it $description", body = body)
     }
@@ -26,7 +26,8 @@ interface TestContainer {
      * @author Ranie Jade Ramiso
      * @since 1.0
      */
-    @Synonym(type = SynonymType.Test, prefix = "it", excluded = true)
+    @Synonym(type = SynonymType.TEST, prefix = "it", excluded = true)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun xit(description: String, reason: String? = null, body: TestBody.() -> Unit = {}) {
         test("it $description", Pending.Yes(reason), body)
     }

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/meta/Synonyms.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/meta/Synonyms.kt
@@ -4,9 +4,9 @@ package org.spekframework.spek2.meta
  * Type of synonym.
  */
 enum class SynonymType {
-    Group,
-    Action,
-    Test
+    GROUP,
+    ACTION,
+    TEST
 }
 
 /**
@@ -22,11 +22,21 @@ annotation class Synonym(val type: SynonymType,
                          val prefix: String = "",
                          val excluded: Boolean = false)
 
+
 /**
  * Controls how descriptions are derived by the IDE.
  *
- * @property desc the description, only applies if annotation is used on a function.
+ * @property sources description sources.
  */
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Description(val desc: String = "")
+annotation class Descriptions(vararg val sources: Description)
+
+enum class DescriptionLocation {
+    TYPE_PARAMETER,
+    VALUE_PARAMETER
+}
+/**
+ * A description source.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Description(val location: DescriptionLocation, val index: Int)

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
@@ -11,14 +11,14 @@ class SpekRunConfigurationProducer: RunConfigurationProducer<SpekBaseRunConfigur
 ) {
     override fun isConfigurationFromContext(configuration: SpekBaseRunConfiguration<*>,
                                             context: ConfigurationContext): Boolean {
-        val path = context.psiLocation?.let(::extractPath)
+        val path = context.psiLocation?.let { extractPath(it, true) }
         return configuration.path == path
     }
 
     override fun setupConfigurationFromContext(configuration: SpekBaseRunConfiguration<*>,
                                                context: ConfigurationContext,
                                                sourceElement: Ref<PsiElement>): Boolean {
-        val path = sourceElement.get().let(::extractPath)
+        val path = sourceElement.get().let { extractPath(it, true) }
         return if (path != null) {
             configuration.path = path
             configuration.setGeneratedName()

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunLineMarkerContributor.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunLineMarkerContributor.kt
@@ -5,11 +5,26 @@ import com.intellij.execution.lineMarker.RunLineMarkerContributor
 import com.intellij.icons.AllIcons
 import com.intellij.psi.PsiElement
 import com.intellij.util.Function
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
 class SpekRunLineMarkerContributor: RunLineMarkerContributor() {
 
     override fun getInfo(element: PsiElement): Info? {
-        val path = extractPath(element)
+        val path = when {
+            // we only highlight identifiers to avoid conflicting line markers
+            isIdentifier(element) -> {
+                val parent = element.parent
+                when(parent) {
+                    // most probably parent is a KtCallExpression
+                    is KtNameReferenceExpression -> extractPath(parent.parent)
+                    is KtClassOrObject -> extractPath(parent)
+                    else -> null
+                }
+            }
+            else -> null
+        }
+
         return path?.let {
             Info(
                 AllIcons.RunConfigurations.TestState.Run,

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/synonym.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/synonym.kt
@@ -1,0 +1,94 @@
+package org.spekframework.intellij
+
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.impl.compiled.ClsArrayInitializerMemberValueImpl
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+
+enum class PsiSynonymType {
+    GROUP,
+    ACTION,
+    TEST
+}
+
+data class PsiSynonym(val annotation: PsiAnnotation) {
+    val type: PsiSynonymType by lazy {
+        val type = annotation.findAttributeValue("type")!!.text
+
+        when {
+            type.endsWith("SynonymType.GROUP") -> PsiSynonymType.GROUP
+            type.endsWith("SynonymType.ACTION") -> PsiSynonymType.ACTION
+            type.endsWith("SynonymType.TEST") -> PsiSynonymType.TEST
+            else -> throw IllegalArgumentException("Unsupported synonym: $type.")
+        }
+    }
+
+    val prefix: String by lazy {
+        annotation.findAttributeValue("prefix")!!.text.removeSurrounding("\"")
+    }
+
+    val excluded: Boolean by lazy {
+        annotation.findAttributeValue("excluded")!!.text.toBoolean()
+    }
+}
+
+enum class PsiDescriptionLocation {
+    TYPE_PARAMETER,
+    VALUE_PARAMETER
+}
+
+class PsiDescription(val annotation: PsiAnnotation) {
+    val index: Int by lazy {
+        annotation.findAttributeValue("index")!!.text.toInt()
+    }
+
+    val location: PsiDescriptionLocation by lazy {
+        val text = annotation.findAttributeValue("location")!!.text
+        when {
+            text.endsWith("DescriptionLocation.TYPE_PARAMETER") -> PsiDescriptionLocation.TYPE_PARAMETER
+            text.endsWith("DescriptionLocation.VALUE_PARAMETER") -> PsiDescriptionLocation.VALUE_PARAMETER
+            else -> throw IllegalArgumentException("Unknown location type: $text")
+        }
+    }
+}
+
+class PsiDescriptions(val annotation: PsiAnnotation) {
+    val sources: Array<PsiDescription> by lazy {
+        val value = annotation.findAttributeValue("sources")!! as ClsArrayInitializerMemberValueImpl
+        val sources = value.initializers.map { it as PsiAnnotation }
+            .map(::PsiDescription)
+        sources.toTypedArray()
+    }
+}
+
+class SynonymContext(val synonym: PsiSynonym, val descriptions: PsiDescriptions) {
+    fun isExcluded(): Boolean = synonym.excluded
+
+    fun constructDescription(callExpression: KtCallExpression): String {
+        return descriptions.sources.map {
+            when (it.location) {
+                PsiDescriptionLocation.TYPE_PARAMETER -> throw UnsupportedFeatureException("Type parameter description is currently unsupported.")
+                PsiDescriptionLocation.VALUE_PARAMETER -> {
+                    val argument = callExpression.valueArguments.getOrNull(it.index)
+                    val expression = argument?.getArgumentExpression()
+
+                    when (expression) {
+                        is KtStringTemplateExpression -> {
+                            if (!expression.hasInterpolation()) {
+                                // might be empty at some point, especially when user is still typing
+                                expression.entries.firstOrNull()?.text ?: ""
+                            } else {
+                                throw UnsupportedFeatureException("Descriptions with interpolation are currently unsupported.")
+                            }
+                        }
+                        // can happen when user is still typing
+                        else -> throw UnsupportedFeatureException("Value argument description should be a string.")
+                    }
+                }
+                else -> throw IllegalArgumentException("Invalid location: ${it.location}")
+            }
+        }.fold(synonym.prefix) { prev, current ->
+            "$prev $current"
+        }
+    }
+}

--- a/spek-runtime/jvm/src/main/kotlin/org/spekframework/spek2/runtime/scope/Path.kt
+++ b/spek-runtime/jvm/src/main/kotlin/org/spekframework/spek2/runtime/scope/Path.kt
@@ -1,7 +1,7 @@
 package org.spekframework.spek2.runtime.scope
 
 import org.spekframework.spek2.Spek
-import java.util.Base64
+import java.util.*
 import kotlin.reflect.KClass
 
 actual data class Path(actual val name: String, actual val parent: Path?) {


### PR DESCRIPTION
Initially planning to implement a new way for the plugin to construct the path, however, I have an encountered a bug while doing so. So this PR does several things now:

- Capitalize `SynonymType` values.
- Introduce `@Descriptions`, so a synonym can now have several sources for description. the plugin will concatenate each source.
- Fix issue with line marker provider not reliably highlighting the proper line, the problem happens when you start typing in the editor.
- Add support for right click run.