### PR TITLE
Bug fixes for running spek from common platform module

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,5 @@ bintrayApiKey=nothing
 systemProp.org.ajoberstar.grgit.auth.hardcoded.allow=nothing
 systemProp.org.ajoberstar.grgit.auth.username=nothing
 systemProp.org.ajoberstar.grgit.auth.password=nothing
+ijSdkVersion=2018.1
+ijSdkKotlinPluginCoords=org.jetbrains.kotlin:1.2.40-release-IJ2018.1-1

--- a/spek-ide-plugin/intellij-common/build.gradle
+++ b/spek-ide-plugin/intellij-common/build.gradle
@@ -2,8 +2,8 @@ apply from: "$rootDir/gradle/common/dependencies.gradle"
 apply from: "$rootDir/gradle/common/idea-plugin.gradle"
 
 intellij {
-    version = '2018.1'
-    plugins = ['org.jetbrains.kotlin:1.2.31-release-IJ2018.1-1']
+    version = ijSdkVersion
+    plugins = [ijSdkKotlinPluginCoords]
 }
 
 dependencies {

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
@@ -2,10 +2,12 @@ package org.spekframework.intellij
 
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.RunConfigurationProducer
-import com.intellij.execution.configurations.ConfigurationTypeUtil
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.config.KotlinFacetSettings
 import org.jetbrains.kotlin.config.KotlinFacetSettingsProvider
 import org.jetbrains.kotlin.config.TargetPlatformKind
 
@@ -40,20 +42,35 @@ abstract class SpekRunConfigurationProducer(val producerType: ProducerType, conf
                 .getInitializedSettings(context.module)
 
             var canRun = false
-            if (kotlinFacetSettings.targetPlatformKind == TargetPlatformKind.Common) {
-                val module = ModuleManager.getInstance(context.project)
-                    .findModuleByName(checkNotNull(kotlinFacetSettings.implementedModuleNames.first()))
-                configuration.setModule(module)
-                canRun = true
-            } else if (isPlatformSupported(kotlinFacetSettings.targetPlatformKind!!)) {
+            if (isPlatformSupported(kotlinFacetSettings.targetPlatformKind!!)) {
                 configuration.setModule(context.module)
                 canRun = true
+            } else  if (kotlinFacetSettings.targetPlatformKind == TargetPlatformKind.Common) {
+                val (module, moduleKotlinFacetSettings) = findSupportedModule(context.project, kotlinFacetSettings)
+                configuration.setModule(module)
+                configuration.producerType = moduleKotlinFacetSettings.targetPlatformKind!!.toProducerType()
+                canRun = true
+            }
+
+            if (canRun) {
+                configuration.setGeneratedName()
             }
 
             canRun
         } else {
             false
         }
+    }
+
+    private fun findSupportedModule(project: Project, commonFacet: KotlinFacetSettings): Pair<Module, KotlinFacetSettings> {
+        val moduleManager = ModuleManager.getInstance(project)
+        val kotlinFacetSettingsProvider = KotlinFacetSettingsProvider.getInstance(project)
+
+        return commonFacet.implementedModuleNames.map { moduleManager.findModuleByName(it)!! }
+            .map { it to kotlinFacetSettingsProvider.getInitializedSettings(it) }
+            .first {
+                isPlatformSupported(it.second.targetPlatformKind!!)
+            }
     }
 
     private fun isPlatformSupported(targetPlatformKind: TargetPlatformKind<*>) = targetPlatformKind.toProducerType() == producerType

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
@@ -3,8 +3,11 @@ package org.spekframework.intellij
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.RunConfigurationProducer
 import com.intellij.execution.configurations.ConfigurationTypeUtil
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.config.KotlinFacetSettingsProvider
+import org.jetbrains.kotlin.config.TargetPlatformKind
 
 class SpekRunConfigurationProducer: RunConfigurationProducer<SpekBaseRunConfiguration<*>>(
     ConfigurationTypeUtil.findConfigurationType(SpekBaseConfigurationType::class.java)
@@ -22,7 +25,18 @@ class SpekRunConfigurationProducer: RunConfigurationProducer<SpekBaseRunConfigur
         return if (path != null) {
             configuration.path = path
             configuration.setGeneratedName()
-            configuration.setModule(context.module)
+            val kotlinFacetSettings = checkNotNull(
+                KotlinFacetSettingsProvider.getInstance(context.project)
+                    .getSettings(context.module)
+            )
+
+            if (kotlinFacetSettings.targetPlatformKind == TargetPlatformKind.Common) {
+                val module = ModuleManager.getInstance(context.project)
+                    .findModuleByName(checkNotNull(kotlinFacetSettings.implementedModuleName))
+                configuration.setModule(module)
+            } else {
+                configuration.setModule(context.module)
+            }
             true
         } else {
             false

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/base.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/base.kt
@@ -8,7 +8,6 @@ import com.intellij.execution.configurations.ModuleBasedConfiguration
 import com.intellij.execution.configurations.RunConfigurationModule
 import com.intellij.openapi.util.JDOMExternalizerUtil
 import org.jdom.Element
-import org.jetbrains.kotlin.idea.KotlinIcons
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.scope.PathBuilder
 import org.spekframework.spek2.runtime.scope.isRoot
@@ -40,6 +39,8 @@ abstract class SpekBaseRunConfiguration<T: RunConfigurationModule>(name: String,
     private var programParameters: String? = null
 
     var path: Path = PathBuilder.ROOT
+
+    var producerType: ProducerType? = null
 
     override fun getWorkingDirectory() = workingDirectory
 
@@ -87,12 +88,16 @@ abstract class SpekBaseRunConfiguration<T: RunConfigurationModule>(name: String,
     override fun suggestedName(): String {
         val parent = path.parent
 
+        val prefix = producerType?.let {
+            "($it)"
+        } ?: ""
+
         return if (path.name.isEmpty()) {
-            "Specs in <default>"
+            "$prefix Specs in <default>"
         } else if (parent != null && parent.isRoot) {
-            "Specs in ${path.name}"
+            "S$prefix pecs in ${path.name}"
         } else {
-            path.name
-        }
+            "$prefix ${path.name}"
+        }.trim()
     }
 }

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/base.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/base.kt
@@ -12,12 +12,13 @@ import org.jetbrains.kotlin.idea.KotlinIcons
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.scope.PathBuilder
 import org.spekframework.spek2.runtime.scope.isRoot
+import javax.swing.Icon
 
-abstract class SpekBaseConfigurationType(id: String, displayName: String): ConfigurationTypeBase(
+abstract class SpekBaseConfigurationType(id: String, displayName: String, icon: Icon): ConfigurationTypeBase(
     id,
     displayName,
     "Run specifications",
-    KotlinIcons.SMALL_LOGO_13
+    icon
 )
 
 enum class ConfigurationKey(val key: String) {

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/synonym.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/synonym.kt
@@ -1,7 +1,7 @@
 package org.spekframework.intellij
 
 import com.intellij.psi.PsiAnnotation
-import com.intellij.psi.impl.compiled.ClsArrayInitializerMemberValueImpl
+import com.intellij.psi.PsiArrayInitializerMemberValue
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
@@ -54,7 +54,7 @@ class PsiDescription(val annotation: PsiAnnotation) {
 
 class PsiDescriptions(val annotation: PsiAnnotation) {
     val sources: Array<PsiDescription> by lazy {
-        val value = annotation.findAttributeValue("sources")!! as ClsArrayInitializerMemberValueImpl
+        val value = annotation.findAttributeValue("sources")!! as PsiArrayInitializerMemberValue
         val sources = value.initializers.map { it as PsiAnnotation }
             .map(::PsiDescription)
         sources.toTypedArray()

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/util.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/util.kt
@@ -1,17 +1,24 @@
 package org.spekframework.intellij
 
 import com.intellij.lang.jvm.JvmModifier
+import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.PsiUtil
+import org.jetbrains.kotlin.asJava.builder.toLightClassOrigin
 import org.jetbrains.kotlin.asJava.classes.KtLightClass
 import org.jetbrains.kotlin.asJava.toLightClass
 import org.jetbrains.kotlin.asJava.toLightMethods
+import org.jetbrains.kotlin.idea.caches.resolve.util.getJavaOrKotlinMemberDescriptor
 import org.jetbrains.kotlin.idea.core.getPackage
 import org.jetbrains.kotlin.idea.refactoring.fqName.getKotlinFqName
+import org.jetbrains.kotlin.idea.refactoring.pullUp.getSuperTypeEntryByDescriptor
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.lexer.KtToken
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
+import org.jetbrains.kotlin.resolve.lazy.data.KtClassInfoUtil
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.scope.PathBuilder
 

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/util.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/util.kt
@@ -80,9 +80,9 @@ fun isInKotlinFile(element: PsiElement): Boolean {
  */
 fun isSpekSubclass(element: KtLightClass?): Boolean {
     if (element != null) {
-        val superClass = element.superClass as KtLightClass?
+        val superClass = element.superClass
 
-        if (superClass != null) {
+        if (superClass != null && superClass is KtLightClass) {
             val fqName = superClass.getKotlinFqName()
             return if (fqName != null && SPEK_CLASSES.contains(fqName.toString())) {
                 true

--- a/spek-ide-plugin/intellij-idea/build.gradle
+++ b/spek-ide-plugin/intellij-idea/build.gradle
@@ -2,8 +2,8 @@ apply from: "$rootDir/gradle/common/dependencies.gradle"
 apply from: "$rootDir/gradle/common/idea-plugin.gradle"
 
 intellij {
-    version = '2018.1'
-    plugins = ['org.jetbrains.kotlin:1.2.31-release-IJ2018.1-1']
+    version = ijSdkVersion
+    plugins = [ijSdkKotlinPluginCoords]
 }
 
 dependencies {

--- a/spek-ide-plugin/intellij-idea/src/main/kotlin/org/spekframework/intellij/spek2.kt
+++ b/spek-ide-plugin/intellij-idea/src/main/kotlin/org/spekframework/intellij/spek2.kt
@@ -1,10 +1,8 @@
 package org.spekframework.intellij
 
-import com.intellij.execution.configurations.ConfigurationFactory
-import com.intellij.execution.configurations.ConfigurationType
-import com.intellij.execution.configurations.JavaRunConfigurationModule
-import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.configurations.*
 import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.idea.KotlinIcons
 
 class Spek2JvmConfigurationFactory(type: ConfigurationType): ConfigurationFactory(type) {
     override fun createTemplateConfiguration(project: Project): RunConfiguration =
@@ -13,9 +11,15 @@ class Spek2JvmConfigurationFactory(type: ConfigurationType): ConfigurationFactor
 
 class Spek2JvmConfigurationType: SpekBaseConfigurationType(
     "org.spekframework.spek2-jvm",
-    "Spek 2 - JVM"
+    "Spek 2 - JVM",
+    KotlinIcons.SMALL_LOGO_13
 ) {
     init {
         addFactory(Spek2JvmConfigurationFactory(this))
     }
 }
+
+class Spek2JvmRunConfigurationProducer: SpekRunConfigurationProducer(
+    ProducerType.JVM,
+    ConfigurationTypeUtil.findConfigurationType(Spek2JvmConfigurationType::class.java)
+)

--- a/spek-ide-plugin/intellij-idea/src/main/resources/META-INF/plugin.xml
+++ b/spek-ide-plugin/intellij-idea/src/main/resources/META-INF/plugin.xml
@@ -19,7 +19,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <configurationType implementation="org.spekframework.intellij.Spek2JvmConfigurationType"/>
-        <runConfigurationProducer implementation="org.spekframework.intellij.SpekRunConfigurationProducer"/>
+        <runConfigurationProducer implementation="org.spekframework.intellij.Spek2JvmRunConfigurationProducer"/>
         <implicitUsageProvider implementation="org.spekframework.intellij.SpekImplicitUsageProvider"/>
         <runLineMarkerContributor language="kotlin" implementationClass="org.spekframework.intellij.SpekRunLineMarkerContributor"/>
     </extensions>

--- a/spek-ide-plugin/intellij-jvm/build.gradle
+++ b/spek-ide-plugin/intellij-jvm/build.gradle
@@ -2,8 +2,8 @@ apply from: "$rootDir/gradle/common/dependencies.gradle"
 apply from: "$rootDir/gradle/common/idea-plugin.gradle"
 
 intellij {
-    version = '2018.1'
-    plugins = ['org.jetbrains.kotlin:1.2.31-release-IJ2018.1-1']
+    version = ijSdkVersion
+    plugins = [ijSdkKotlinPluginCoords]
 }
 
 dependencies {


### PR DESCRIPTION
Once this gets answered: https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000435044--Kotlin-PSI-Check-if-class-is-a-subclass-of-a-particular-class-that-works-for-JVM-and-Common-platforms-,  we should be able to run tests from the common module.