### PR TITLE
Allow running of Spek classes from a common module

### DIFF
--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekImplicitUsageProvider.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekImplicitUsageProvider.kt
@@ -2,7 +2,7 @@ package org.spekframework.intellij
 
 import com.intellij.codeInsight.daemon.ImplicitUsageProvider
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.asJava.classes.KtLightClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
 
 class SpekImplicitUsageProvider: ImplicitUsageProvider {
     override fun isImplicitWrite(element: PsiElement) = false
@@ -10,7 +10,7 @@ class SpekImplicitUsageProvider: ImplicitUsageProvider {
     override fun isImplicitRead(element: PsiElement) = false
 
     override fun isImplicitUsage(element: PsiElement): Boolean {
-        if (element is KtLightClass) {
+        if (element is KtClassOrObject) {
             return isSpekSubclass(element) && isSpekRunnable(element)
         }
         return false


### PR DESCRIPTION
Now it is possible to do this:

![common](https://user-images.githubusercontent.com/1041919/39697212-76590124-5233-11e8-931f-a741d408f662.PNG)

I still need to work on highlighting the synonyms, but at least we know it's possible.