### PR TITLE
Rename Pending metadata to Skip.

### DIFF
--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/GroupBody.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/GroupBody.kt
@@ -8,11 +8,11 @@ import org.spekframework.spek2.meta.*
 interface GroupBody : TestContainer, ScopeBody {
     @Synonym(type = SynonymType.GROUP)
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
-    fun group(description: String, pending: Pending = Pending.No, body: GroupBody.() -> Unit)
+    fun group(description: String, skip: Skip = Skip.No, body: GroupBody.() -> Unit)
 
     @Synonym(type = SynonymType.ACTION)
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
-    fun action(description: String, pending: Pending = Pending.No, body: ActionBody.() -> Unit)
+    fun action(description: String, skip: Skip = Skip.No, body: ActionBody.() -> Unit)
 
     fun <T> memoized(mode: CachingMode = CachingMode.TEST, factory: () -> T): MemoizedValue<T>
     fun <T> memoized(mode: CachingMode = CachingMode.TEST, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T>

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/Pending.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/Pending.kt
@@ -1,6 +1,0 @@
-package org.spekframework.spek2.dsl
-
-sealed class Pending constructor(val pending: Boolean) {
-    class Yes(val reason: String? = null) : Pending(true)
-    object No : Pending(false)
-}

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/Skip.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/Skip.kt
@@ -1,0 +1,6 @@
+package org.spekframework.spek2.dsl
+
+sealed class Skip {
+    class Yes(val reason: String? = null) : Skip()
+    object No : Skip()
+}

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/TestContainer.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/dsl/TestContainer.kt
@@ -6,5 +6,5 @@ import org.spekframework.spek2.meta.*
 interface TestContainer {
     @Synonym(type = SynonymType.TEST)
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
-    fun test(description: String, pending: Pending = Pending.No, body: TestBody.() -> Unit)
+    fun test(description: String, skip: Skip = Skip.No, body: TestBody.() -> Unit)
 }

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/style/gherkin/Gherkin.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/style/gherkin/Gherkin.kt
@@ -2,7 +2,7 @@ package org.spekframework.spek2.style.gherkin
 
 import org.spekframework.spek2.dsl.ActionBody
 import org.spekframework.spek2.dsl.GroupBody
-import org.spekframework.spek2.dsl.Pending
+import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.dsl.TestBody
 import org.spekframework.spek2.meta.*
 
@@ -10,8 +10,8 @@ import org.spekframework.spek2.meta.*
 class Feature(delegate: GroupBody) : GroupBody by delegate {
     @Synonym(SynonymType.ACTION, prefix = "Scenario: ")
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
-    fun Scenario(description: String, pending: Pending = Pending.No, body: Scenario.() -> Unit) {
-        action("Scenario: $description", pending) {
+    fun Scenario(description: String, skip: Skip = Skip.No, body: Scenario.() -> Unit) {
+        action("Scenario: $description", skip) {
             body(Scenario(this))
         }
     }
@@ -40,8 +40,8 @@ class Scenario(delegate: ActionBody) : ActionBody by delegate {
 
 @Synonym(SynonymType.GROUP, prefix = "Feature: ")
 @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
-fun GroupBody.Feature(description: String, pending: Pending = Pending.No, body: Feature.() -> Unit) {
-    group("Feature: $description", pending) {
+fun GroupBody.Feature(description: String, skip: Skip = Skip.No, body: Feature.() -> Unit) {
+    group("Feature: $description", skip) {
         body(Feature(this))
     }
 }

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/style/specification/Specification.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/style/specification/Specification.kt
@@ -1,7 +1,7 @@
 package org.spekframework.spek2.style.specification
 
 import org.spekframework.spek2.dsl.GroupBody
-import org.spekframework.spek2.dsl.Pending
+import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.dsl.TestBody
 import org.spekframework.spek2.meta.*
 
@@ -9,38 +9,38 @@ import org.spekframework.spek2.meta.*
 class Suite(delegate: GroupBody) : GroupBody by delegate {
     @Synonym(SynonymType.GROUP)
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
-    fun describe(description: String, pending: Pending = Pending.No, body: Suite.() -> Unit) {
-        createSuite(description, pending, body)
+    fun describe(description: String, skip: Skip = Skip.No, body: Suite.() -> Unit) {
+        createSuite(description, skip, body)
     }
 
     @Synonym(SynonymType.GROUP)
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
-    fun context(description: String, pending: Pending = Pending.No, body: Suite.() -> Unit) {
-        createSuite(description, pending, body)
+    fun context(description: String, skip: Skip = Skip.No, body: Suite.() -> Unit) {
+        createSuite(description, skip, body)
     }
 
     @Synonym(SynonymType.GROUP, excluded = true)
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun xdescribe(description: String, reason: String = "", body: Suite.() -> Unit) {
-        createSuite(description, Pending.Yes(reason), body)
+        createSuite(description, Skip.Yes(reason), body)
     }
 
     @Synonym(SynonymType.GROUP, excluded = true)
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun xcontext(description: String, reason: String = "", body: Suite.() -> Unit) {
-        createSuite(description, Pending.Yes(reason), body)
+        createSuite(description, Skip.Yes(reason), body)
     }
 
     @Synonym(SynonymType.TEST)
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
-    fun it(description: String, pending: Pending = Pending.No, body: TestBody.() -> Unit) {
-        createTest(description, pending, body)
+    fun it(description: String, skip: Skip = Skip.No, body: TestBody.() -> Unit) {
+        createTest(description, skip, body)
     }
 
     @Synonym(SynonymType.TEST, excluded = true)
     @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun xit(description: String, reason: String = "", body: TestBody.() -> Unit) {
-        createTest(description, Pending.Yes(reason), body)
+        createTest(description, Skip.Yes(reason), body)
     }
 
     fun before(cb: () -> Unit) {
@@ -62,22 +62,22 @@ class Suite(delegate: GroupBody) : GroupBody by delegate {
 
 @Synonym(SynonymType.GROUP)
 @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
-fun GroupBody.describe(description: String, pending: Pending = Pending.No, body: Suite.() -> Unit) {
-    createSuite(description, pending, body)
+fun GroupBody.describe(description: String, skip: Skip = Skip.No, body: Suite.() -> Unit) {
+    createSuite(description, skip, body)
 }
 
 @Synonym(SynonymType.GROUP)
 @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
 fun GroupBody.xdescribe(description: String, reason: String = "", body: Suite.() -> Unit) {
-    createSuite(description, Pending.Yes(reason), body)
+    createSuite(description, Skip.Yes(reason), body)
 }
 
-private fun GroupBody.createSuite(description: String, pending: Pending, body: Suite.() -> Unit) {
-    group(description, pending) {
+private fun GroupBody.createSuite(description: String, skip: Skip, body: Suite.() -> Unit) {
+    group(description, skip) {
         body(Suite(this))
     }
 }
 
-private fun GroupBody.createTest(description: String, pending: Pending, body: TestBody.() -> Unit) {
-    test(description, pending, body)
+private fun GroupBody.createTest(description: String, skip: Skip, body: TestBody.() -> Unit) {
+    test(description, skip, body)
 }

--- a/spek-runner/junit5/src/test/kotlin/org/spekframework/spek2/junit/SpekTestDescriptorFactoryTest.kt
+++ b/spek-runner/junit5/src/test/kotlin/org/spekframework/spek2/junit/SpekTestDescriptorFactoryTest.kt
@@ -5,7 +5,7 @@ import com.natpryce.hamkrest.sameInstance
 import com.nhaarman.mockito_kotlin.mock
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.spekframework.spek2.dsl.Pending
+import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.runtime.lifecycle.LifecycleManager
 import org.spekframework.spek2.runtime.scope.GroupScopeImpl
 import org.spekframework.spek2.runtime.scope.PathBuilder
@@ -34,7 +34,7 @@ class SpekTestDescriptorFactoryTest {
             ScopeId(ScopeType.Class, "SomeClass"),
             path,
             null,
-            Pending.No,
+            Skip.No,
             lifecycleManager
         )
 

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/Collectors.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/Collectors.kt
@@ -38,12 +38,12 @@ open class Collector(
         lifecycleManager.addListener(listener)
     }
 
-    override fun group(description: String, pending: Pending, body: GroupBody.() -> Unit) {
+    override fun group(description: String, skip: Skip, body: GroupBody.() -> Unit) {
         val group = GroupScopeImpl(
             idFor(description),
             root.path.resolve(description),
             root,
-            pending,
+            skip,
             lifecycleManager
         )
         root.addChild(group)
@@ -58,7 +58,7 @@ open class Collector(
                     root.path.resolve("Group Failure"),
                     root,
                     {},
-                    pending,
+                    skip,
                     lifecycleManager
                 )
             )
@@ -66,7 +66,7 @@ open class Collector(
 
     }
 
-    override fun action(description: String, pending: Pending, body: ActionBody.() -> Unit) {
+    override fun action(description: String, skip: Skip, body: ActionBody.() -> Unit) {
         val action = ActionScopeImpl(
             idFor(description),
             root.path.resolve(description),
@@ -74,20 +74,20 @@ open class Collector(
             {
                 body.invoke(ActionCollector(this, lifecycleManager, it, this@Collector::idFor))
             },
-            pending,
+            skip,
             lifecycleManager
         )
 
         root.addChild(action)
     }
 
-    override fun test(description: String, pending: Pending, body: TestBody.() -> Unit) {
+    override fun test(description: String, skip: Skip, body: TestBody.() -> Unit) {
         val test = TestScopeImpl(
             idFor(description),
             root.path.resolve(description),
             root,
             body,
-            pending,
+            skip,
             lifecycleManager
         )
         root.addChild(test)
@@ -128,13 +128,13 @@ class ActionCollector(
         return MemoizedValueReader(root)
     }
 
-    override fun test(description: String, pending: Pending, body: TestBody.() -> Unit) {
+    override fun test(description: String, skip: Skip, body: TestBody.() -> Unit) {
         val test = TestScopeImpl(
             idFor(description),
             root.path.resolve(description),
             root,
             body,
-            pending,
+            skip,
             lifecycleManager
         )
         root.addChild(test)

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/Executor.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/Executor.kt
@@ -1,6 +1,6 @@
 package org.spekframework.spek2.runtime
 
-import org.spekframework.spek2.dsl.Pending
+import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.runtime.execution.ExecutionContext
 import org.spekframework.spek2.runtime.execution.ExecutionResult
 import org.spekframework.spek2.runtime.scope.ActionScopeImpl
@@ -17,8 +17,8 @@ class Executor {
     }
 
     private fun execute(scope: ScopeImpl, context: ExecutionContext) {
-        if (scope.pending is Pending.Yes) {
-            scopeIgnored(scope, scope.pending.reason, context)
+        if (scope.skip is Skip.Yes) {
+            scopeIgnored(scope, scope.skip.reason, context)
         } else {
             scopeExecutionStarted(scope, context)
             val result = executeSafely {

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
@@ -1,7 +1,7 @@
 package org.spekframework.spek2.runtime
 
 import org.spekframework.spek2.Spek
-import org.spekframework.spek2.dsl.Pending
+import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.runtime.execution.DiscoveryRequest
 import org.spekframework.spek2.runtime.execution.DiscoveryResult
 import org.spekframework.spek2.runtime.execution.ExecutionContext
@@ -23,7 +23,7 @@ abstract class AbstractRuntime {
 
         val qualifiedName = (path.parent?.name ?: "") + ".${path.name}"
         val classScope =
-            GroupScopeImpl(ScopeId(ScopeType.Class, qualifiedName), path, null, Pending.No, lifecycleManager)
+            GroupScopeImpl(ScopeId(ScopeType.Class, qualifiedName), path, null, Skip.No, lifecycleManager)
         instance.root.invoke(Collector(classScope, lifecycleManager, fixtures))
 
         return classScope

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/scope/Scopes.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/scope/Scopes.kt
@@ -1,6 +1,6 @@
 package org.spekframework.spek2.runtime.scope
 
-import org.spekframework.spek2.dsl.Pending
+import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.dsl.TestBody
 import org.spekframework.spek2.lifecycle.*
 import org.spekframework.spek2.runtime.execution.ExecutionContext
@@ -11,7 +11,7 @@ import kotlin.properties.ReadOnlyProperty
 sealed class ScopeImpl(
     val id: ScopeId,
     val path: Path,
-    val pending: Pending,
+    val skip: Skip,
     val lifecycleManager: LifecycleManager
 ) : Scope {
 
@@ -38,9 +38,9 @@ open class GroupScopeImpl(
     id: ScopeId,
     path: Path,
     override val parent: GroupScope?,
-    pending: Pending,
+    skip: Skip,
     lifecycleManager: LifecycleManager
-) : ScopeImpl(id, path, pending, lifecycleManager), GroupScope {
+) : ScopeImpl(id, path, skip, lifecycleManager), GroupScope {
 
     private val children = mutableListOf<ScopeImpl>()
 
@@ -81,9 +81,9 @@ class ActionScopeImpl(
     path: Path,
     parent: GroupScope?,
     private val body: ActionScopeImpl.(ExecutionContext) -> Unit,
-    pending: Pending,
+    skip: Skip,
     lifecycleManager: LifecycleManager
-) : GroupScopeImpl(id, path, parent, pending, lifecycleManager), ActionScope {
+) : GroupScopeImpl(id, path, parent, skip, lifecycleManager), ActionScope {
 
     override fun before(context: ExecutionContext) {
         lifecycleManager.beforeExecuteAction(this)
@@ -103,9 +103,9 @@ class TestScopeImpl(
     path: Path,
     override val parent: GroupScope,
     private val body: TestBody.() -> Unit,
-    pending: Pending,
+    skip: Skip,
     lifecycleManager: LifecycleManager
-) : ScopeImpl(id, path, pending, lifecycleManager), TestScope {
+) : ScopeImpl(id, path, skip, lifecycleManager), TestScope {
 
     override fun before(context: ExecutionContext) {
         lifecycleManager.beforeExecuteTest(this)

--- a/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/SkipTest.kt
+++ b/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/SkipTest.kt
@@ -4,36 +4,36 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.junit.jupiter.api.Test
 import org.spekframework.spek2.Spek
-import org.spekframework.spek2.dsl.Pending
+import org.spekframework.spek2.dsl.Skip
 
-class PendingTest : AbstractSpekRuntimeTest() {
+class SkipTest : AbstractSpekRuntimeTest() {
     @Test
-    fun testPendingGroup() {
-        class PendingSpek : Spek({
+    fun testSkipGroup() {
+        class SkipSpek : Spek({
             group("foo") {
                 test("bar") { }
             }
 
-            group("a pending foo", Pending.Yes()) {
-                test("a bar inside a pending foo") { }
+            group("a skip foo", Skip.Yes()) {
+                test("a bar inside a skip foo") { }
             }
         })
 
-        val recorder = executeTestsForClass(PendingSpek::class)
+        val recorder = executeTestsForClass(SkipSpek::class)
 
         assertThat(recorder.containerIgnoredCount, equalTo(1))
     }
 
     @Test
-    fun testPendingTest() {
-        class PendingSpek : Spek({
+    fun testSkipTest() {
+        class SkipSpek : Spek({
             group("foo") {
                 test("bar") { }
-                test("a pending bar", pending = Pending.Yes()) { }
+                test("a skip bar", skip = Skip.Yes()) { }
             }
         })
 
-        val recorder = executeTestsForClass(PendingSpek::class)
+        val recorder = executeTestsForClass(SkipSpek::class)
 
         assertThat(recorder.testStartedCount, equalTo(1))
         assertThat(recorder.testIgnoredCount, equalTo(1))


### PR DESCRIPTION
I was totally confused by the naming when reading the code since the name doesn’t quite match the meaning. It is used for exclusion, i. e. for `xdescribe` and `xcontext`.

The naming does not align with [the RSpec terms](https://relishapp.com/rspec/rspec-core/v/3-7/docs/pending-and-skipped-examples) as well.

> An example can either be marked as skipped, in which is it not executed, or pending in which it is executed but failure will not cause a failure of the entire suite. 