### PR TITLE
Remove execution context.

### DIFF
--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/lifecycle/ActionScope.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/lifecycle/ActionScope.kt
@@ -1,3 +1,0 @@
-package org.spekframework.spek2.lifecycle
-
-interface ActionScope : GroupScope

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/lifecycle/LifecycleListener.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/lifecycle/LifecycleListener.kt
@@ -5,6 +5,4 @@ interface LifecycleListener {
     fun afterExecuteTest(test: TestScope) = Unit
     fun beforeExecuteGroup(group: GroupScope) = Unit
     fun afterExecuteGroup(group: GroupScope) = Unit
-    fun beforeExecuteAction(action: ActionScope) = Unit
-    fun afterExecuteAction(action: ActionScope) = Unit
 }

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/meta/Synonyms.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/meta/Synonyms.kt
@@ -9,7 +9,7 @@ enum class SynonymType {
 }
 
 /**
- * Marks a function as a synonym to either a group, action or test scope.
+ * Marks a function as a synonym to either a group or test scope.
  *
  * @property type type of scope.
  * @property prefix prefix appended to the description (if applicable), this will appear in the test report.

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/synonym.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/synonym.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
 enum class PsiSynonymType {
     GROUP,
-    ACTION,
     TEST
 }
 
@@ -17,7 +16,6 @@ data class PsiSynonym(val annotation: PsiAnnotation) {
 
         when {
             type.endsWith("SynonymType.GROUP") -> PsiSynonymType.GROUP
-            type.endsWith("SynonymType.ACTION") -> PsiSynonymType.ACTION
             type.endsWith("SynonymType.TEST") -> PsiSynonymType.TEST
             else -> throw IllegalArgumentException("Unsupported synonym: $type.")
         }

--- a/spek-ide-plugin/interop-jvm/src/main/kotlin/org/spekframework/ide/ServiceMessageAdapter.kt
+++ b/spek-ide-plugin/interop-jvm/src/main/kotlin/org/spekframework/ide/ServiceMessageAdapter.kt
@@ -2,7 +2,6 @@ package org.spekframework.ide
 
 import org.spekframework.spek2.runtime.execution.ExecutionListener
 import org.spekframework.spek2.runtime.execution.ExecutionResult
-import org.spekframework.spek2.runtime.scope.ActionScopeImpl
 import org.spekframework.spek2.runtime.scope.GroupScopeImpl
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.scope.TestScopeImpl
@@ -57,29 +56,6 @@ class ServiceMessageAdapter: ExecutionListener {
 
     override fun groupIgnored(group: GroupScopeImpl, reason: String?) {
         val name = group.path.name.toServiceMessageSafeString()
-        out("testIgnored name='$name' ignoreComment='${reason ?: "no reason provided"}'")
-        out("testFinished name='$name'")
-    }
-
-    override fun actionExecutionStart(action: ActionScopeImpl) {
-        out("testSuiteStarted name='${action.path.name.toServiceMessageSafeString()}'")
-    }
-
-    override fun actionExecutionFinish(action: ActionScopeImpl, result: ExecutionResult) {
-        val name = action.path.name.toServiceMessageSafeString()
-        if (result is ExecutionResult.Failure) {
-            val exceptionDetails = getExceptionDetails(result)
-
-            // fake a child test
-            out("testStarted name='$name'")
-            out("testFailed name='$name' message='${exceptionDetails.first}' details='${exceptionDetails.second}'")
-            out("testFinished name='$name'")
-        }
-        out("testSuiteFinished name='$name'")
-    }
-
-    override fun actionIgnored(action: ActionScopeImpl, reason: String?) {
-        val name = action.path.name.toServiceMessageSafeString()
         out("testIgnored name='$name' ignoreComment='${reason ?: "no reason provided"}'")
         out("testFinished name='$name'")
     }

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/JUnitEngineExecutionListenerAdapter.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/JUnitEngineExecutionListenerAdapter.kt
@@ -4,7 +4,6 @@ import org.junit.platform.engine.EngineExecutionListener
 import org.junit.platform.engine.TestExecutionResult
 import org.spekframework.spek2.runtime.execution.ExecutionListener
 import org.spekframework.spek2.runtime.execution.ExecutionResult
-import org.spekframework.spek2.runtime.scope.ActionScopeImpl
 import org.spekframework.spek2.runtime.scope.GroupScopeImpl
 import org.spekframework.spek2.runtime.scope.ScopeImpl
 import org.spekframework.spek2.runtime.scope.TestScopeImpl
@@ -23,13 +22,7 @@ class JUnitEngineExecutionListenerAdapter(
     override fun executionFinish() = Unit
 
     override fun testExecutionStart(test: TestScopeImpl) {
-        val descriptor = test.asJUnitDescriptor()
-
-        if (test.parent is ActionScopeImpl) {
-            listener.dynamicTestRegistered(descriptor)
-        }
-
-        listener.executionStarted(descriptor)
+        listener.executionStarted(test.asJUnitDescriptor())
     }
 
     override fun testExecutionFinish(test: TestScopeImpl, result: ExecutionResult) {
@@ -50,18 +43,6 @@ class JUnitEngineExecutionListenerAdapter(
 
     override fun groupIgnored(group: GroupScopeImpl, reason: String?) {
         listener.executionSkipped(group.asJUnitDescriptor(), reason ?: DEFAULT_IGNORE_REASON)
-    }
-
-    override fun actionExecutionStart(action: ActionScopeImpl) {
-        listener.executionStarted(action.asJUnitDescriptor())
-    }
-
-    override fun actionExecutionFinish(action: ActionScopeImpl, result: ExecutionResult) {
-        listener.executionFinished(action.asJUnitDescriptor(), result.asJUnitResult())
-    }
-
-    override fun actionIgnored(action: ActionScopeImpl, reason: String?) {
-        listener.executionSkipped(action.asJUnitDescriptor(), reason ?: DEFAULT_IGNORE_REASON)
     }
 
     private fun ScopeImpl.asJUnitDescriptor() = factory.create(this)

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptor.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptor.kt
@@ -34,7 +34,6 @@ class SpekTestDescriptor internal constructor(
 
     override fun getType(): TestDescriptor.Type = when (scope) {
         is GroupScopeImpl -> TestDescriptor.Type.CONTAINER
-        is ActionScopeImpl -> TestDescriptor.Type.CONTAINER_AND_TEST
         is TestScopeImpl -> TestDescriptor.Type.TEST
     }
 
@@ -70,7 +69,7 @@ class SpekTestDescriptor internal constructor(
 
     override fun getChildren() = childDescriptors
 
-    override fun mayRegisterTests(): Boolean = scope is ActionScopeImpl
+    override fun mayRegisterTests(): Boolean = false
 
     override fun getTags(): MutableSet<TestTag> = mutableSetOf()
 

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptor.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptor.kt
@@ -69,8 +69,6 @@ class SpekTestDescriptor internal constructor(
 
     override fun getChildren() = childDescriptors
 
-    override fun mayRegisterTests(): Boolean = false
-
     override fun getTags(): MutableSet<TestTag> = mutableSetOf()
 
     override fun removeFromHierarchy() = throw UnsupportedOperationException()

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/FixturesAdapter.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/FixturesAdapter.kt
@@ -1,6 +1,5 @@
 package org.spekframework.spek2.runtime
 
-import org.spekframework.spek2.lifecycle.ActionScope
 import org.spekframework.spek2.lifecycle.GroupScope
 import org.spekframework.spek2.lifecycle.LifecycleListener
 import org.spekframework.spek2.lifecycle.TestScope
@@ -14,23 +13,11 @@ class FixturesAdapter : LifecycleListener {
     private val afterGroup: LinkedHashMap<GroupScope, MutableList<() -> Unit>> = LinkedHashMap()
 
     override fun beforeExecuteTest(test: TestScope) {
-        if (test.parent !is ActionScope) {
-            invokeAllBeforeEachTest(test.parent)
-        }
+        invokeAllBeforeEachTest(test.parent)
     }
 
     override fun afterExecuteTest(test: TestScope) {
-        if (test.parent !is ActionScope) {
-            invokeAllAfterEachTest(test.parent)
-        }
-    }
-
-    override fun beforeExecuteAction(action: ActionScope) {
-        invokeAllBeforeEachTest(action)
-    }
-
-    override fun afterExecuteAction(action: ActionScope) {
-        invokeAllAfterEachTest(action)
+        invokeAllAfterEachTest(test.parent)
     }
 
     override fun beforeExecuteGroup(group: GroupScope) {

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
@@ -4,7 +4,6 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.runtime.execution.DiscoveryRequest
 import org.spekframework.spek2.runtime.execution.DiscoveryResult
-import org.spekframework.spek2.runtime.execution.ExecutionContext
 import org.spekframework.spek2.runtime.execution.ExecutionRequest
 import org.spekframework.spek2.runtime.lifecycle.LifecycleManager
 import org.spekframework.spek2.runtime.scope.GroupScopeImpl
@@ -29,9 +28,7 @@ abstract class AbstractRuntime {
         return classScope
     }
 
-    fun execute(request: ExecutionRequest) {
-        Executor().execute(ExecutionContext(request))
-    }
+    fun execute(request: ExecutionRequest) = Executor().execute(request)
 }
 
 expect class SpekRuntime() : AbstractRuntime

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/execution/Execution.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/execution/Execution.kt
@@ -1,9 +1,10 @@
 package org.spekframework.spek2.runtime.execution
 
-import org.spekframework.spek2.runtime.scope.ActionScopeImpl
 import org.spekframework.spek2.runtime.scope.GroupScopeImpl
 import org.spekframework.spek2.runtime.scope.ScopeImpl
 import org.spekframework.spek2.runtime.scope.TestScopeImpl
+
+data class ExecutionRequest(val roots: List<ScopeImpl>, val executionListener: ExecutionListener)
 
 sealed class ExecutionResult {
     object Success : ExecutionResult()
@@ -21,14 +22,4 @@ interface ExecutionListener {
     fun groupExecutionStart(group: GroupScopeImpl)
     fun groupExecutionFinish(group: GroupScopeImpl, result: ExecutionResult)
     fun groupIgnored(group: GroupScopeImpl, reason: String?)
-
-    fun actionExecutionStart(action: ActionScopeImpl)
-    fun actionExecutionFinish(action: ActionScopeImpl, result: ExecutionResult)
-    fun actionIgnored(action: ActionScopeImpl, reason: String?)
-}
-
-data class ExecutionRequest(val roots: List<ScopeImpl>, val executionListener: ExecutionListener)
-
-data class ExecutionContext(val request: ExecutionRequest) {
-    val executionListener = request.executionListener
 }

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/LifecycleManager.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/LifecycleManager.kt
@@ -1,6 +1,5 @@
 package org.spekframework.spek2.runtime.lifecycle
 
-import org.spekframework.spek2.lifecycle.ActionScope
 import org.spekframework.spek2.lifecycle.GroupScope
 import org.spekframework.spek2.lifecycle.LifecycleListener
 import org.spekframework.spek2.lifecycle.TestScope
@@ -32,13 +31,5 @@ class LifecycleManager {
 
     fun afterExecuteGroup(group: GroupScope) {
         listeners.reversed().forEach { it.afterExecuteGroup(group) }
-    }
-
-    fun beforeExecuteAction(action: ActionScope) {
-        listeners.forEach { it.beforeExecuteAction(action) }
-    }
-
-    fun afterExecuteAction(action: ActionScope) {
-        listeners.reversed().forEach { it.afterExecuteAction(action) }
     }
 }

--- a/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/MemoizedValueAdapter.kt
+++ b/spek-runtime/common/src/main/kotlin/org/spekframework/spek2/runtime/lifecycle/MemoizedValueAdapter.kt
@@ -1,6 +1,5 @@
 package org.spekframework.spek2.runtime.lifecycle
 
-import org.spekframework.spek2.lifecycle.ActionScope
 import org.spekframework.spek2.lifecycle.GroupScope
 import org.spekframework.spek2.lifecycle.LifecycleListener
 import org.spekframework.spek2.lifecycle.TestScope
@@ -79,16 +78,6 @@ sealed class MemoizedValueAdapter<T>(
     ) : MemoizedValueAdapter<T>(factory, destructor) {
 
         override fun afterExecuteTest(test: TestScope) {
-            if (test.parent !is ActionScope) {
-                val cached = this.cached
-                when (cached) {
-                    is Cached.Value<T> -> destructor(cached.value)
-                }
-                this.cached = Cached.Empty
-            }
-        }
-
-        override fun afterExecuteAction(action: ActionScope) {
             val cached = this.cached
             when (cached) {
                 is Cached.Value<T> -> destructor(cached.value)

--- a/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/ExecutionEventRecorder.kt
+++ b/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/ExecutionEventRecorder.kt
@@ -2,7 +2,6 @@ package org.spekframework.spek2.jvm
 
 import org.spekframework.spek2.runtime.execution.ExecutionListener
 import org.spekframework.spek2.runtime.execution.ExecutionResult
-import org.spekframework.spek2.runtime.scope.ActionScopeImpl
 import org.spekframework.spek2.runtime.scope.GroupScopeImpl
 import org.spekframework.spek2.runtime.scope.TestScopeImpl
 
@@ -57,18 +56,6 @@ class ExecutionEventRecorder : ExecutionListener {
 
     override fun groupIgnored(group: GroupScopeImpl, reason: String?) {
         _executionEvents.add(ExecutionEvent.Ignored(group, reason))
-    }
-
-    override fun actionExecutionStart(action: ActionScopeImpl) {
-        _executionEvents.add(ExecutionEvent.Started(action))
-    }
-
-    override fun actionExecutionFinish(action: ActionScopeImpl, result: ExecutionResult) {
-        _executionEvents.add(ExecutionEvent.Finished(action, result))
-    }
-
-    override fun actionIgnored(action: ActionScopeImpl, reason: String?) {
-        _executionEvents.add(ExecutionEvent.Ignored(action, reason))
     }
 
     private inline fun <reified T : ExecutionResult> getTestFinishedEventsByStatus(): Sequence<ExecutionEvent.Finished> {


### PR DESCRIPTION
`ExecutionContext` was just a wrapper on top of `ExecutionRequest` and wasn’t actually used anywhere except `Executor`.

Had to remove a bunch of `Action`-related code @artem-zinnatullin forgot about.