### PR TITLE
Use DynamicTestExecutor to fix incompatibility

### DIFF
--- a/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/Scope.kt
+++ b/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/Scope.kt
@@ -32,7 +32,7 @@ sealed class Scope(uniqueId: UniqueId, val pending: Pending, val source: TestSou
     class Action(uniqueId: UniqueId, pending: Pending,
                  source: TestSource?,
                  lifecycleManager: LifecycleManager,
-                 private val body: Action.(SpekExecutionContext) -> Unit)
+                 private val body: Action.(Node.DynamicTestExecutor) -> Unit)
         : Scope(uniqueId, pending, source, lifecycleManager), ActionScope {
         override fun getType() = CONTAINER
 
@@ -41,11 +41,11 @@ sealed class Scope(uniqueId: UniqueId, val pending: Pending, val source: TestSou
             return context
         }
 
-        override fun execute(context: SpekExecutionContext, dynamicTestExecutor: Node.DynamicTestExecutor?): SpekExecutionContext {
+        override fun execute(context: SpekExecutionContext, dynamicTestExecutor: Node.DynamicTestExecutor): SpekExecutionContext {
             val collector = ThrowableCollector()
 
             if (collector.isEmpty()) {
-                collector.executeSafely { body.invoke(this, context) }
+                collector.executeSafely { body.invoke(this, dynamicTestExecutor) }
             }
 
             collector.assertEmpty()

--- a/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekExecutionContext.kt
+++ b/spek-junit-platform-engine/src/main/kotlin/org/jetbrains/spek/engine/SpekExecutionContext.kt
@@ -1,13 +1,8 @@
 package org.jetbrains.spek.engine
 
-import org.junit.platform.engine.EngineExecutionListener
-import org.junit.platform.engine.ExecutionRequest
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext
 
 /**
  * @author Ranie Jade Ramiso
  */
-class SpekExecutionContext(val executionRequest: ExecutionRequest): EngineExecutionContext {
-    val engineExecutionListener: EngineExecutionListener
-        get() = executionRequest.engineExecutionListener
-}
+class SpekExecutionContext: EngineExecutionContext

--- a/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/ActionTest.kt
+++ b/spek-junit-platform-engine/src/test/kotlin/org/jetbrains/spek/engine/ActionTest.kt
@@ -34,7 +34,7 @@ class ActionTest: AbstractSpekTestEngineTest() {
         val recorder = executeTestsForClass(TestSpek::class)
 
         assertThat(recorder.dynamicTestRegisteredCount, equalTo(2))
-        assertThat(recorder.testSuccessfulCount, equalTo(1))
-        assertThat(recorder.testFailureCount, equalTo(1))
+        assertThat(recorder.testSuccessfulCount, equalTo(2))
+        assertThat(recorder.testFailureCount, equalTo(0))
     }
 }


### PR DESCRIPTION
Prior to this commit the dynamically discovered tests were reported to the `EngineExecutionListener` directly which caused an incompatibility with JUnit Platform 1.3.

However, merging this PR would change the runtime behavior. Previously, a scope block was executed entirely before executing the first test. Now, the tests are executed immediately when they are encountered.

Is this acceptable or do we need a different solution?

Fixes #462.