### PR TITLE
Verify entire Spek can be skipped

### DIFF
--- a/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/ExecutionEventRecorder.kt
+++ b/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/ExecutionEventRecorder.kt
@@ -16,6 +16,8 @@ class ExecutionEventRecorder : ExecutionListener {
         get() = countTestEventsByType<ExecutionEvent.Started>()
     val containerStartedCount: Int
         get() = countContainerEventsByType<ExecutionEvent.Started>()
+    val containerFinishedCount: Int
+        get() = countContainerEventsByType<ExecutionEvent.Finished>()
     val testFinishedCount: Int
         get() = countTestEventsByType<ExecutionEvent.Finished>()
     val testSuccessfulCount: Int

--- a/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/SkipTest.kt
+++ b/spek-runtime/jvm/src/test/kotlin/org/spekframework/spek2/jvm/SkipTest.kt
@@ -5,6 +5,7 @@ import com.natpryce.hamkrest.equalTo
 import org.junit.jupiter.api.Test
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.dsl.Skip
+import org.spekframework.spek2.style.specification.xdescribe
 
 class SkipTest : AbstractSpekRuntimeTest() {
     @Test
@@ -37,5 +38,25 @@ class SkipTest : AbstractSpekRuntimeTest() {
 
         assertThat(recorder.testStartedCount, equalTo(1))
         assertThat(recorder.testIgnoredCount, equalTo(1))
+    }
+
+    @Test
+    fun testSkipEntireSpek() {
+        class SkipEntireSpek : Spek({
+            group("foo", Skip.Yes()) {
+
+            }
+        })
+
+        val recorder = executeTestsForClass(SkipEntireSpek::class)
+
+        assertThat(recorder.containerIgnoredCount, equalTo(1))
+        assertThat(recorder.containerFailureCount, equalTo(0))
+        assertThat(recorder.containerStartedCount, equalTo(1)) // Root container.
+        assertThat(recorder.containerFinishedCount, equalTo(1))
+
+        assertThat(recorder.testStartedCount, equalTo(0))
+        assertThat(recorder.testIgnoredCount, equalTo(0))
+        assertThat(recorder.testFailureCount, equalTo(0))
     }
 }


### PR DESCRIPTION
PR adds integration test that verifies that we don't crash execution if nothing was executed in the Spek due to `group(skip = Yes)`

Related to #475 