### PR TITLE
Make doc deploy part of travis release step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ jobs:
     - stage: build
       script: ./gradlew --no-daemon --info --stacktrace clean build
     - stage: release
-      script: ./gradlew --no-daemon --info --stacktrace bintrayUpload
+      script:
+        - ./gradlew --no-daemon --info --stacktrace bintrayUpload
+        - curl -X POST -d '' $NETLIFY_DEPLOY_URL
 
 stages:
   - build


### PR DESCRIPTION
Docs will now only be deployed when a release happens.

`NETLIFY_DEPLOY_URL` is set in travis.