### PR TITLE
Add android docs

### DIFF
--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -2,7 +2,7 @@
 For non-android modules in your project you can follow the [JVM](setup-jvm.md) instructions.
 
 ```groovy
-// junit5 doesn't support android projects out of the box
+// Required as JUnit 5 doesn't support android projects out of the box.
 apply plugin: "de.mannodermaus.android-junit5"
 
 android {

--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -1,0 +1,46 @@
+# Setting up for Android
+For non-android modules in your project you can follow the [JVM](setup-jvm.md) instructions.
+
+```groovy
+// junit5 doesn't support android projects out of the box
+apply plugin: "de.mannodermaus.android-junit5"
+
+android {
+    ...
+
+    // Add Kotlin source directory to all source sets
+    sourceSets.each {
+        it.java.srcDirs += "src/$it.name/kotlin"
+    }
+
+    testOptions {
+        junitPlatform {
+            filters {
+                engines {
+                    include 'spek2'
+                }
+            }
+            jacocoOptions {
+                // here goes all jacoco config, for example
+                html.enabled = true
+                xml.enabled = false
+                csv.enabled = false
+                unitTests.all {
+                    testLogging.events = ["passed", "skipped", "failed"]
+                }
+            }
+        }
+    }
+}
+
+dependencies {
+    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    // spek
+    testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
+    testImplementation "org.spekframework.spek2:spek-runner-junit5:$spek_version"
+
+    // spek requires kotlin-reflect, omit when already in classpath
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+}
+```

--- a/docs/setup-mpp.md
+++ b/docs/setup-mpp.md
@@ -1,1 +1,0 @@
-# Setting up for Multiplatform

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,7 @@ pages:
   - Migrating to 2.x: migration.md
   - Setting up:
     - JVM: setup-jvm.md
-    - Multiplatform: setup-mpp.md
+    - Android: setup-android.md
   - Core Concepts: core-concepts.md
   - Styles:
     - Specification: specification.md

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
 
@@ -60,8 +60,8 @@ dependencies {
 
     // spek2
     testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
-    // testRuntimeOnly not working, todo: fix plugin
     testImplementation "org.spekframework.spek2:spek-runner-junit5:$spek_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestRuntimeOnly "de.mannodermaus.junit5:android-instrumentation-test-runner:$junit5_runner"


### PR DESCRIPTION
Also drops the multiplatform docs, for now - it was empty anyway. Multiplatform project setup is still evolving and I don't want to place two versions of the DSL in the docs. 