### PR TITLE
Adding full spec description

### DIFF
--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptor.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptor.kt
@@ -33,7 +33,7 @@ class SpekTestDescriptor internal constructor(
 
     override fun getUniqueId() = id
 
-    override fun getDisplayName(): String = scope.path.name
+    override fun getDisplayName(): String = scope.path.toString()
 
     override fun getType(): TestDescriptor.Type = when (scope) {
         is GroupScopeImpl -> TestDescriptor.Type.CONTAINER


### PR DESCRIPTION
When using nested describes and contexts, gradle's test runner (and IntelliJ's) only print the innermost test's descriptions. [Gradle's JUnit 5 runner ignores all containers](https://github.com/gradle/gradle/blob/68ce07583cfbfb92164141bdf57cd707764bd469/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java#L102) ([see also](https://github.com/gradle/gradle/blob/68ce07583cfbfb92164141bdf57cd707764bd469/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java#L74-L79)), so the hierarchy is lost in the output.  This caused some ambiguity for me when figuring out test failures.

The patch uses the full path instead of the name. A more robust solution for compatibility with Spek might involve sending a PR to gradle, but that's a larger undertaking. 

My [patched version](
https://bintray.com/bernerbrau/bernerbrau/spek2/2.0.0-alpha.2.136%2B20180913T033324Z) can be tested using the following gradle code changes:

```
repositories {
    maven { url "https://dl.bintray.com/bernerbrau/bernerbrau" }
}

dependencies {
    testCompile "org.spekframework.spek2:spek-dsl-jvm:2.0.0-alpha.2.136+20180913T033324Z"
    testRuntime "org.spekframework.spek2:spek-runner-junit5:2.0.0-alpha.2.136+20180913T033324Z"
}
```