### PR TITLE
Resolve Gradle deprecation warning

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -74,7 +74,7 @@ def artifact(Publication publication, Project project, artifactName) {
 
     configure.resolveStrategy =  Closure.DELEGATE_FIRST
     configure.delegate = publication
-    configure()
+    project.afterEvaluate(configure)
 }
 
 publishing {
@@ -89,13 +89,7 @@ publishing {
     }
 }
 
-def artifacts = [
-    'dslCommon',
-    'dslJvm',
-    'runtimeCommon',
-    'runtimeJvm',
-    'runnerJUnit5'
-]
+def artifacts = publishing.publications.collect { it.name }
 
 String propOrEnv(String name) {
     String property = project.findProperty(name)

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,8 @@ pluginManagement {
     }
 }
 
+enableFeaturePreview("STABLE_PUBLISHING")
+
 rootProject.name = 'spek'
 
 include 'spek-dsl:common'


### PR DESCRIPTION
This PR enables the 'STABLE_PUBLISHING' feature preview which will become mandatory in Gradle 5.0. It changes the `publishing` extension to behave like any other Gradle extensions. Since its evaluation is no longer deferred, the `distribution` subproject needs to explicitly postpone configuring its publications until the corresponding subprojects have been evaluated. Otherwise, references to tasks and the `java` component won't work. As a bonus, the publication names can now be reused at configuration time to configure the `bintray` extension without having to duplicate them.