### PR TITLE
Update IJ plugin to work with Kotlin 1.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ artifactory_user=http://nowhere
 systemProp.org.ajoberstar.grgit.auth.hardcoded.allow=nothing
 systemProp.org.ajoberstar.grgit.auth.username=nothing
 systemProp.org.ajoberstar.grgit.auth.password=nothing
-ijSdkVersion=2018.2
-ijSdkKotlinPluginCoords=org.jetbrains.kotlin:1.2.71-release-IJ2018.2-1
+ijSdkVersion=2018.2.5
+ijSdkKotlinPluginCoords=org.jetbrains.kotlin:1.3.0-release-IJ2018.2-1
 org.gradle.jvmargs=--add-modules=java.xml.bind,java.activation -XX:+IgnoreUnrecognizedVMOptions

--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
@@ -50,7 +50,7 @@ abstract class SpekRunConfigurationProducer(val producerType: ProducerType, conf
             if (isPlatformSupported(kotlinFacetSettings.platform!!.kind)) {
                 configuration.setModule(context.module)
                 canRun = true
-            } else  if (kotlinFacetSettings.platform!!.kind == CommonIdePlatformKind) {
+            } else if (kotlinFacetSettings.platform!!.kind == CommonIdePlatformKind) {
                 val result = findSupportedModule(context.project, context.module)
                 if (result != null) {
                     val (module, moduleKotlinFacetSettings) = result


### PR DESCRIPTION
Resolves #523. When this is merged, IJ plugin will require kotlin 1.3 IJ plugin to be installed.