### PR TITLE
Fix path generation when prefix is available

### DIFF
--- a/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/synonym.kt
+++ b/spek-ide-plugin/intellij-common/src/main/kotlin/org/spekframework/intellij/synonym.kt
@@ -95,7 +95,7 @@ class SynonymContext(val synonym: PsiSynonym, val descriptions: PsiDescriptions)
             }
         }.fold(synonym.prefix) { prev, current ->
             if (prev.isNotEmpty()) {
-                "$prev $current"
+                "$prev$current"
             } else {
                 current
             }


### PR DESCRIPTION
Resolves #518. Silly mistake, there's an extra space when the plugin is generating the path for the selected scope.

//cc: @NitroG42