### PR TITLE
Add runnable flag to Synonym annotation

### DIFF
--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/meta/synonyms.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/meta/synonyms.kt
@@ -14,13 +14,15 @@ enum class SynonymType {
  * @property type type of scope.
  * @property prefix prefix appended to the description (if applicable), this will appear in the test report.
  * @property excluded whether the synonym represents an ignored scope.
+ * @property runnable controls whether this scope is runnable from within the IDE.
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Synonym(
     val type: SynonymType,
     val prefix: String = "",
-    val excluded: Boolean = false
+    val excluded: Boolean = false,
+    val runnable: Boolean = true
 )
 
 

--- a/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/style/gherkin/gherkinStyle.kt
+++ b/spek-dsl/common/src/main/kotlin/org/spekframework/spek2/style/gherkin/gherkinStyle.kt
@@ -27,18 +27,26 @@ class FeatureBody(val delegate: GroupBody): LifecycleAware by delegate {
 
 @SpekDsl
 class ScenarioBody(val delegate: GroupBody): LifecycleAware by delegate {
+    @Synonym(SynonymType.TEST, prefix = "Given: ", runnable = false)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun Given(description: String, body: TestBody.() -> Unit) {
         delegate.test("Given: $description", body = body)
     }
 
+    @Synonym(SynonymType.TEST, prefix = "When: ", runnable = false)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun When(description: String, body: TestBody.() -> Unit) {
         delegate.test("When: $description", body = body)
     }
 
+    @Synonym(SynonymType.TEST, prefix = "Then: ", runnable = false)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun Then(description: String, body: TestBody.() -> Unit) {
         delegate.test("Then: $description", body = body)
     }
 
+    @Synonym(SynonymType.TEST, prefix = "And: ", runnable = false)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
     fun And(description: String, body: TestBody.() -> Unit) {
         delegate.test("And: $description", body = body)
     }


### PR DESCRIPTION
Primary purpose is to allow IJ plugin to discover scopes that can't be run individually (`Given`, `When`, `Then` and `And`). This is needed so `Navigate to source` works with the gherkin style.