### PR TITLE
Spek1 over Spek2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -28,6 +28,8 @@ if (hasProperty("localAndroidStudio")) {
     include 'spek-ide-plugin:android-studio'
 }
 
+include 'spek-compat'
+
 include 'integration-test:common'
 include 'integration-test:jvm'
 

--- a/spek-compat/build.gradle
+++ b/spek-compat/build.gradle
@@ -1,0 +1,24 @@
+apply from: "$rootDir/gradle/common/dependencies.gradle"
+apply from: "$rootDir/gradle/common/kotlin-jvm.gradle"
+
+test {
+    useJUnitPlatform {
+        includeEngines 'spek2'
+    }
+}
+
+dependencies {
+    compile project(':spek-dsl:jvm')
+}
+
+dependencies {
+    testImplementation 'com.natpryce:hamkrest'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin'
+    testImplementation 'org.junit.platform:junit-platform-engine'
+    testImplementation 'org.junit.platform:junit-platform-launcher'
+
+    // enable final class mocking
+    testRuntimeOnly 'org.mockito:mockito-inline'
+    testRuntimeOnly project(':spek-runner:junit5')
+}

--- a/spek-compat/src/main/kotlin/org/jetbrains/spek/api/compat/ActionBody.kt
+++ b/spek-compat/src/main/kotlin/org/jetbrains/spek/api/compat/ActionBody.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.spek.api.compat
+
+import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.dsl.GroupBody
+import org.spekframework.spek2.dsl.TestBody
+import org.spekframework.spek2.meta.*
+
+class ActionBody(val scope: GroupBody) {
+    @Synonym(SynonymType.TEST, prefix = "it ", runnable = false)
+    @Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+    fun it(description: String, body: TestBody.() -> Unit) {
+        scope.it(description, body)
+    }
+}

--- a/spek-compat/src/main/kotlin/org/jetbrains/spek/api/dsl/standard.kt
+++ b/spek-compat/src/main/kotlin/org/jetbrains/spek/api/dsl/standard.kt
@@ -1,0 +1,73 @@
+package org.jetbrains.spek.api.dsl
+
+import org.jetbrains.spek.api.compat.ActionBody
+import org.spekframework.spek2.dsl.GroupBody
+import org.spekframework.spek2.dsl.Skip
+import org.spekframework.spek2.dsl.TestBody
+import org.spekframework.spek2.dsl.TestContainer
+import org.spekframework.spek2.meta.*
+
+
+@Synonym(SynonymType.GROUP, prefix = "describe ")
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun GroupBody.describe(description: String, body: GroupBody.() -> Unit) {
+    group("describe $description", body = body)
+}
+
+@Synonym(SynonymType.GROUP, prefix = "context ")
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun GroupBody.context(description: String, body: GroupBody.() -> Unit) {
+    group("context $description", body = body)
+}
+
+@Synonym(SynonymType.GROUP, prefix = "given ")
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun GroupBody.given(description: String, body: GroupBody.() -> Unit) {
+    group("given $description", body = body)
+}
+
+@Synonym(SynonymType.GROUP, prefix = "on ")
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun GroupBody.on(description: String, body: ActionBody.() -> Unit) {
+    group("on $description") {
+        beforeGroup { body(ActionBody(this)) }
+    }
+}
+
+@Synonym(SynonymType.TEST, prefix = "it ")
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun TestContainer.it(description: String, body: TestBody.() -> Unit) {
+    test("it $description", body = body)
+}
+
+@Synonym(SynonymType.GROUP, prefix = "describe ", excluded = true)
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun GroupBody.xdescribe(description: String, reason: String? = null, body: GroupBody.() -> Unit) {
+    group("describe $description", Skip.Yes(reason), body = body)
+}
+
+@Synonym(SynonymType.GROUP, prefix = "context ", excluded = true)
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun GroupBody.xcontext(description: String, reason: String? = null, body: GroupBody.() -> Unit) {
+    group("context $description", Skip.Yes(reason), body = body)
+}
+
+@Synonym(SynonymType.GROUP, prefix = "given ", excluded = true)
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun GroupBody.xgiven(description: String, reason: String? = null, body: GroupBody.() -> Unit) {
+    group("given $description", Skip.Yes(reason), body = body)
+}
+
+@Synonym(SynonymType.GROUP, prefix = "on ", excluded = true)
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun GroupBody.xon(description: String, reason: String? = null, body: ActionBody.() -> Unit = {}) {
+    group("on $description", Skip.Yes(reason)) {
+        beforeGroup { body(ActionBody(this)) }
+    }
+}
+
+@Synonym(SynonymType.TEST, prefix = "it ", excluded = true)
+@Descriptions(Description(DescriptionLocation.VALUE_PARAMETER, 0))
+fun TestContainer.xit(description: String, reason: String? = null, body: TestBody.() -> Unit = {}) {
+    test("it $description", Skip.Yes(reason), body)
+}

--- a/spek-compat/src/test/kotlin/org/jetbrains/spek/SampleTest.kt
+++ b/spek-compat/src/test/kotlin/org/jetbrains/spek/SampleTest.kt
@@ -1,0 +1,21 @@
+package org.jetbrains.spek
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.on
+import org.spekframework.spek2.Spek
+
+object SampleTest: Spek({
+    given("a list") {
+        val list by memoized { mutableListOf<String>() }
+
+        on("adding an item") {
+            list.add("spek")
+
+            it("should have a size of one") {
+                assertThat(list.size, equalTo(1))
+            }
+        }
+    }
+})


### PR DESCRIPTION
Implemented for the lolz - not to be merged. Spek 1 implemented (partly) on top of Spek 2. Several caveats.

- Use `org.spekframework.spek2.Spek` instead of Spek 1's equivalent: `org.jetbrains.spek.api.Spek`.
- No subject support use `val subject by memoized { ... }`.
- No data-driven support.
- Not tested, possibly riddled with 🐛 .