### PR TITLE
Fix run marker showing up for method call

### DIFF
--- a/spek-ide-plugin/intellij-base/src/main/kotlin/org/spekframework/intellij/SpekRunLineMarkerContributor.kt
+++ b/spek-ide-plugin/intellij-base/src/main/kotlin/org/spekframework/intellij/SpekRunLineMarkerContributor.kt
@@ -14,17 +14,12 @@ import org.spekframework.intellij.util.maybeGetContext
 class SpekRunLineMarkerContributor: RunLineMarkerContributor() {
 
     override fun getInfo(element: PsiElement): Info? {
-        if (element !is KtNameReferenceExpression) {
-            return null
-        }
-
         val descriptorCache = checkNotNull(
             element.project.getComponent(ScopeDescriptorCache::class.java)
         )
-        val context = maybeGetContext(element)
-        val descriptor = when (context) {
-            is KtClassOrObject -> descriptorCache.fromClassOrObject(context)
-            is KtCallExpression -> descriptorCache.fromCallExpression(context)
+        val descriptor = when (element) {
+            is KtClassOrObject -> descriptorCache.fromClassOrObject(element)
+            is KtCallExpression -> descriptorCache.fromCallExpression(element)
             else -> null
         }
 


### PR DESCRIPTION
Fix is not getting the **context** of a method call. 

```
it("should do something") {
   set.add(1)
}
```

The context of `set.add(1)` is  enclosing scope (`it(...)`)