### PR TITLE
Avoid doing child recalculation for cached junit descriptor

### DIFF
--- a/integration-test/common/src/test/kotlin/org/spekframework/spek2/integration/FixturesTest.kt
+++ b/integration-test/common/src/test/kotlin/org/spekframework/spek2/integration/FixturesTest.kt
@@ -56,3 +56,11 @@ object FixturesTest: Spek({
         }
     }
 })
+
+object LargeTest: Spek({
+    repeat(27000) {
+        test("test $it") {
+
+        }
+    }
+})

--- a/integration-test/common/src/test/kotlin/org/spekframework/spek2/integration/FixturesTest.kt
+++ b/integration-test/common/src/test/kotlin/org/spekframework/spek2/integration/FixturesTest.kt
@@ -56,11 +56,3 @@ object FixturesTest: Spek({
         }
     }
 })
-
-object LargeTest: Spek({
-    repeat(27000) {
-        test("test $it") {
-
-        }
-    }
-})

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptorFactory.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptorFactory.kt
@@ -9,13 +9,23 @@ class SpekTestDescriptorFactory {
 
     fun create(scope: ScopeImpl): SpekTestDescriptor = createDescriptor(scope)
 
-    private fun createDescriptor(scope: ScopeImpl) = cache.computeIfAbsent(scope) {
-        SpekTestDescriptor(scope, this).apply {
-            if (scope is GroupScopeImpl) {
-                scope.getChildren().forEach { child ->
-                    this.addChild(create(child))
+    private fun createDescriptor(scope: ScopeImpl): SpekTestDescriptor {
+        var cached = true
+        val descriptor = cache.computeIfAbsent(scope) {
+            cached = false
+            SpekTestDescriptor(scope, this)
+        }
+
+        if (!cached) {
+            descriptor.apply {
+                if (scope is GroupScopeImpl) {
+                    scope.getChildren().forEach { child ->
+                        this.addChild(create(child))
+                    }
                 }
             }
         }
+
+        return descriptor
     }
 }

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptorFactory.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptorFactory.kt
@@ -7,15 +7,15 @@ class SpekTestDescriptorFactory {
 
     private val cache = mutableMapOf<ScopeImpl, SpekTestDescriptor>()
 
-    fun create(scope: ScopeImpl): SpekTestDescriptor = createDescriptor(scope).apply {
-        if (scope is GroupScopeImpl) {
-            scope.getChildren().forEach { child ->
-                this.addChild(create(child))
-            }
-        }
-    }
+    fun create(scope: ScopeImpl): SpekTestDescriptor = createDescriptor(scope)
 
     private fun createDescriptor(scope: ScopeImpl) = cache.computeIfAbsent(scope) {
-        SpekTestDescriptor(scope, this)
+        SpekTestDescriptor(scope, this).apply {
+            if (scope is GroupScopeImpl) {
+                scope.getChildren().forEach { child ->
+                    this.addChild(create(child))
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
We cache the value but re-run the child calculation every time regardless if we hit the cache or not.

This test is fast when running within IJ but super slow when running via JUnit 5.

```kotlin
object LargeTest: Spek({
    repeat(27000) {
        test("test $it") {

        }
    }
})
```