### PR TITLE
Publish every commit to spek-dev bintray repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,15 @@ jobs:
       script:
         - ./gradlew --no-daemon --info --stacktrace bintrayUpload
         - curl -X POST -d '' $NETLIFY_DEPLOY_URL
+    - stage: release-dev
+      script: ./gradlew --no-daemon --info --stacktrace bintrayUpload
 
 stages:
   - build
   - name: release
     if: tag IS present
+  - name: release-dev
+    if: tag IS NOT present AND type IS NOT pull_request
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ stages:
   - name: release
     if: tag IS present
   - name: release-dev
-    if: tag IS NOT present AND type IS NOT pull_request
+    if: tag IS NOT present AND type != pull_request
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[ ![Download](https://api.bintray.com/packages/spekframework/spek/spek2/images/download.svg) ](https://bintray.com/spekframework/spek/spek2/_latestVersion)
-[![CI](https://travis-ci.org/spekframework/spek.svg?branch=2.x)](https://travis-ci.org/spekframework/spek)
+[ ![CI](https://travis-ci.org/spekframework/spek.svg?branch=2.x) ](https://travis-ci.org/spekframework/spek)
+[ ![Download](https://img.shields.io/bintray/v/spekframework/spek/spek2.svg?label=stable) ](https://bintray.com/spekframework/spek/spek2/_latestVersion)
+[ ![Download](https://img.shields.io/bintray/v/spekframework/spek-dev/spek2.svg?label=dev) ](https://bintray.com/spekframework/spek-dev/spek2/_latestVersion)
 
 ![Spek Logo](spek-logo.png)
 

--- a/gradle/common/publish.gradle
+++ b/gradle/common/publish.gradle
@@ -21,15 +21,17 @@ def bintrayUser = propOrEnv("BINTRAY_USER")
 def bintrayApiKey = propOrEnv("BINTRAY_API_KEY")
 
 def bintrayRepo = 'spek-dev'
+def doPublish = true
 if ("$version".matches("^\\d+\\.\\d+\\.\\d+(-rc\\.\\d+)?")) {
     bintrayRepo = 'spek'
+    doPublish = false
 }
 
 def artifacts = publishing.publications.collect { it.name }
 bintray {
     user = bintrayUser
     key = bintrayApiKey
-    publish = false
+    publish = doPublish
     pkg {
         repo = bintrayRepo
         desc = "Test framework for Kotlin"


### PR DESCRIPTION
Now every commit to `2.x` will trigger a deploy to https://bintray.com/spekframework/spek-dev. This makes easy for anyone to test the latest changes. 