### PR TITLE
Make the build fail when an error is thrown during the discovery phase

### DIFF
--- a/spek-runner/junit5/src/test/kotlin/org/spekframework/spek2/junit/RunnerTests.kt
+++ b/spek-runner/junit5/src/test/kotlin/org/spekframework/spek2/junit/RunnerTests.kt
@@ -50,4 +50,36 @@ class RunnerTests {
 
         assertThat(summary.testsSucceededCount, equalTo(1L))
     }
+
+    @Test
+    fun testFailDuringRootDiscoveryPhase() {
+        val listener = SummaryGeneratingListener()
+        launcher.execute(
+            LauncherDiscoveryRequestBuilder.request()
+                .filters(EngineFilter.includeEngines("spek2"))
+                .selectors(DiscoverySelectors.selectClass("testData.package1.SpekTestWithFailureDuringRootDiscoveryPhase"))
+                .build(),
+            listener
+        )
+
+        val summary = listener.summary
+
+        assertThat(summary.totalFailureCount, equalTo(1L))
+    }
+
+  @Test
+  fun testFailDuringGroupDiscoveryPhase() {
+    val listener = SummaryGeneratingListener()
+    launcher.execute(
+        LauncherDiscoveryRequestBuilder.request()
+            .filters(EngineFilter.includeEngines("spek2"))
+            .selectors(DiscoverySelectors.selectClass("testData.package1.SpekTestWithFailureDuringGroupDiscoveryPhase"))
+            .build(),
+        listener
+    )
+
+    val summary = listener.summary
+
+    assertThat(summary.totalFailureCount, equalTo(1L))
+  }
 }

--- a/spek-runner/junit5/src/test/kotlin/testData/package1/SpekTestWithFailureDuringGroupDiscoveryPhase.kt
+++ b/spek-runner/junit5/src/test/kotlin/testData/package1/SpekTestWithFailureDuringGroupDiscoveryPhase.kt
@@ -1,0 +1,10 @@
+package testData.package1
+
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object SpekTestWithFailureDuringGroupDiscoveryPhase : Spek({
+    describe("group") {
+        throw Exception()
+    }
+})

--- a/spek-runner/junit5/src/test/kotlin/testData/package1/SpekTestWithFailureDuringRootDiscoveryPhase.kt
+++ b/spek-runner/junit5/src/test/kotlin/testData/package1/SpekTestWithFailureDuringRootDiscoveryPhase.kt
@@ -1,0 +1,7 @@
+package testData.package1
+
+import org.spekframework.spek2.Spek
+
+object SpekTestWithFailureDuringRootDiscoveryPhase : Spek({
+    throw Exception()
+})


### PR DESCRIPTION
Fix #566 

I wrote two tests which reproduced the initial problem.

Then I applied the solution proposed by @raniejade [here](https://github.com/spekframework/spek/issues/566#issuecomment-456767646). And it made the tests pass again.

Thanks for your help @raniejade.