### PR TITLE
Fix Working Directory and JRE Fields in Plugin UI

### DIFF
--- a/spek-ide-plugin/android-studio/src/main/kotlin/org/spekframework/intellij/SpekAndroidSettingsEditor.kt
+++ b/spek-ide-plugin/android-studio/src/main/kotlin/org/spekframework/intellij/SpekAndroidSettingsEditor.kt
@@ -57,9 +57,12 @@ class SpekAndroidSettingsEditor(project: Project): SettingsEditor<SpekAndroidRun
         moduleSelector.reset(configuration)
         commonJavaParameters.reset(configuration)
         selectedPath = configuration.data.path
+        jrePathEditor.setPathOrName(configuration.alternativeJrePath, configuration.isAlternativeJrePathEnabled)
     }
 
     override fun applyEditorTo(configuration: SpekAndroidRunConfiguration) {
+        configuration.alternativeJrePath = jrePathEditor.jrePathOrName
+        configuration.isAlternativeJrePathEnabled = jrePathEditor.isAlternativeJreSelected
         configuration.setModule(selectedModule)
         moduleSelector.applyTo(configuration)
         commonJavaParameters.applyTo(configuration)

--- a/spek-ide-plugin/intellij-base/src/main/kotlin/org/spekframework/intellij/SpekRunConfiguration.kt
+++ b/spek-ide-plugin/intellij-base/src/main/kotlin/org/spekframework/intellij/SpekRunConfiguration.kt
@@ -23,7 +23,7 @@ interface SpekRunConfiguration<T: SpekCommonProgramRunConfigurationParameters>: 
     }
 
     override fun setWorkingDirectory(value: String?) {
-        data.workingDirectory = workingDirectory
+        data.workingDirectory = value
     }
 
     override fun setEnvs(envs: MutableMap<String, String>) {

--- a/spek-ide-plugin/intellij-idea/src/main/kotlin/org/spekframework/intellij/SpekJvmSettingsEditor.kt
+++ b/spek-ide-plugin/intellij-idea/src/main/kotlin/org/spekframework/intellij/SpekJvmSettingsEditor.kt
@@ -57,9 +57,12 @@ class SpekJvmSettingsEditor(project: Project): SettingsEditor<SpekJvmRunConfigur
         moduleSelector.reset(configuration)
         commonJavaParameters.reset(configuration)
         selectedPath = configuration.data.path
+        jrePathEditor.setPathOrName(configuration.alternativeJrePath, configuration.isAlternativeJrePathEnabled)
     }
 
     override fun applyEditorTo(configuration: SpekJvmRunConfiguration) {
+        configuration.alternativeJrePath = jrePathEditor.jrePathOrName
+        configuration.isAlternativeJrePathEnabled = jrePathEditor.isAlternativeJreSelected
         configuration.setModule(selectedModule)
         moduleSelector.applyTo(configuration)
         commonJavaParameters.applyTo(configuration)


### PR DESCRIPTION
Previously the `data.workingDirectory` field was set to itself instead of the intended value, meaning it was wiped every time the run configuration was modified; now it is set correctly.

Similar story with the `alternativeJrePath` properties.  Found these while researching #563.