### PR TITLE
Upgrade to Kotlin 1.3.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.3.11
+kotlinVersion=1.3.20
 junitPlatformVersion=1.1.1
 kotlin.incremental=true
 githubRepo=https://github.com/spekframework/spek

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -26,7 +26,6 @@ kotlin {
 
         jvmTest {
             dependencies {
-//                implementation 'org.jetbrains.kotlin:kotlin-test'
                 runtimeOnly kotlin('reflect')
                 runtimeOnly project(':spek-runner:junit5')
             }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -2,34 +2,32 @@ apply plugin: 'kotlin-multiplatform'
 apply from: "$rootDir/gradle/common/dependencies.gradle"
 
 kotlin {
-    targets {
-        fromPreset(presets.jvm, 'jvm')
-    }
+    jvm()
 
     sourceSets {
         commonMain {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
+                implementation kotlin('stdlib')
             }
         }
 
         commonTest {
             dependencies {
                 implementation project(':spek-dsl')
-                implementation 'org.jetbrains.kotlin:kotlin-test-common'
+                implementation kotlin('test')
             }
         }
 
         jvmMain {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+                implementation kotlin('stdlib-jdk8')
             }
         }
 
         jvmTest {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-test'
-                runtimeOnly 'org.jetbrains.kotlin:kotlin-reflect'
+//                implementation 'org.jetbrains.kotlin:kotlin-test'
+                runtimeOnly kotlin('reflect')
                 runtimeOnly project(':spek-runner:junit5')
             }
         }

--- a/spek-dsl/build.gradle
+++ b/spek-dsl/build.gradle
@@ -5,24 +5,22 @@ apply from: "$rootDir/gradle/common/publish.gradle"
 
 
 kotlin {
-    targets {
-        fromPreset(presets.jvm, 'jvm') {
-            mavenPublication {
-                artifactId = "spek-dsl-jvm"
-            }
+    jvm() {
+        mavenPublication {
+            artifactId = "spek-dsl-jvm"
         }
     }
 
     sourceSets {
         commonMain {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
+                implementation kotlin('stdlib')
             }
         }
 
         jvmMain {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+                implementation kotlin('stdlib-jdk8')
             }
         }
     }

--- a/spek-runtime/build.gradle
+++ b/spek-runtime/build.gradle
@@ -4,26 +4,24 @@ apply from: "$rootDir/gradle/common/dependencies.gradle"
 apply from: "$rootDir/gradle/common/publish.gradle"
 
 kotlin {
-    targets {
-        fromPreset(presets.jvm, 'jvm') {
-            mavenPublication {
-                artifactId = 'spek-runtime-jvm'
-            }
+    jvm() {
+        mavenPublication {
+            artifactId = 'spek-runtime-jvm'
         }
     }
 
     sourceSets {
         commonMain {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
+                implementation kotlin('stdlib')
                 api project(':spek-dsl')
             }
         }
 
         jvmMain {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-                implementation 'org.jetbrains.kotlin:kotlin-reflect'
+                implementation kotlin('stdlib-jdk8')
+                implementation kotlin('reflect')
                 implementation 'io.github.classgraph:classgraph'
             }
         }


### PR DESCRIPTION
Resolves https://github.com/spekframework/spek/issues/590.

I've switched to the simpler syntax for referring to Kotlin dependencies (eg. stdlib), but haven't touched anything in the IntelliJ plugins, as they're using the non-MPP Gradle plugin. 