### PR TITLE
Re order build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
 
 stages:
   - build
+  - build-jdk11
   - name: release
     if: tag IS present AND repo = "spekframework/spek"
   - name: release-dev


### PR DESCRIPTION
so whenever `jdk11` stage fails then the release stages are not triggered.

Resolves #598 