### PR TITLE
Refactor DiscoveryContext API

### DIFF
--- a/integration-test/src/jvmTest/kotlin/org/spekframework/spek2/integration/InstanceFactoryTest.kt
+++ b/integration-test/src/jvmTest/kotlin/org/spekframework/spek2/integration/InstanceFactoryTest.kt
@@ -12,7 +12,6 @@ object CustomFactory: InstanceFactory {
     override fun <T : Spek> create(spek: KClass<T>): T {
         return spek.constructors.first().call(PARAM_VALUE)
     }
-
 }
 
 @CreateWith(CustomFactory::class)

--- a/integration-test/src/nativeTest/kotlin/Test.kt
+++ b/integration-test/src/nativeTest/kotlin/Test.kt
@@ -2,19 +2,18 @@ import kotlin.system.exitProcess
 import org.spekframework.spek2.integration.*
 import org.spekframework.spek2.launcher.ConsoleLauncher
 import org.spekframework.spek2.runtime.discovery.DiscoveryContext
-import org.spekframework.spek2.runtime.discovery.addClass
 
 fun main(args: Array<String>) {
     val discoveryContext = DiscoveryContext.builder()
-            .addClass { CalculatorSpecs }
-            .addClass { EmptyGroupTest }
-            .addClass { CalculatorSpecs }
-            .addClass { MemoizedTests }
-            .addClass { NonUniquePathTest }
-            .addClass { SetFeature }
-            .addClass { SetSpec }
-            .addClass { SkipTest }
-            .build()
+        .addTest { CalculatorSpecs }
+        .addTest { EmptyGroupTest }
+        .addTest { CalculatorSpecs }
+        .addTest { MemoizedTests }
+        .addTest { NonUniquePathTest }
+        .addTest { SetFeature }
+        .addTest { SetSpec }
+        .addTest { SkipTest }
+        .build()
 
     val launcher = ConsoleLauncher()
     val exitCode = launcher.launch(discoveryContext, args.toList())

--- a/spek-ide-plugin/interop-jvm/src/main/kotlin/org/spekframework/ide/console.kt
+++ b/spek-ide-plugin/interop-jvm/src/main/kotlin/org/spekframework/ide/console.kt
@@ -2,8 +2,8 @@ package org.spekframework.ide
 
 import com.xenomachina.argparser.ArgParser
 import com.xenomachina.argparser.mainBody
+import org.spekframework.spek2.runtime.JvmDiscoveryContextFactory
 import org.spekframework.spek2.runtime.SpekRuntime
-import org.spekframework.spek2.runtime.discovery.DiscoveryContext
 import org.spekframework.spek2.runtime.execution.DiscoveryRequest
 import org.spekframework.spek2.runtime.execution.ExecutionRequest
 import org.spekframework.spek2.runtime.scope.PathBuilder
@@ -14,8 +14,8 @@ class Spek2ConsoleLauncher {
             PathBuilder.parse(it)
                 .build()
         }
-
-        val discoveryRequest = DiscoveryRequest(DiscoveryContext(mapOf()), args.sourceDirs.toList(), paths)
+        val context = JvmDiscoveryContextFactory.create(args.sourceDirs.toList())
+        val discoveryRequest = DiscoveryRequest(context, paths)
 
         val runtime = SpekRuntime()
 

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
@@ -5,8 +5,8 @@ import org.junit.platform.engine.TestDescriptor
 import org.junit.platform.engine.TestEngine
 import org.junit.platform.engine.UniqueId
 import org.junit.platform.engine.discovery.*
+import org.spekframework.spek2.runtime.JvmDiscoveryContextFactory
 import org.spekframework.spek2.runtime.SpekRuntime
-import org.spekframework.spek2.runtime.discovery.DiscoveryContext
 import org.spekframework.spek2.runtime.execution.DiscoveryRequest
 import org.spekframework.spek2.runtime.execution.ExecutionRequest
 import org.spekframework.spek2.runtime.scope.Path
@@ -74,7 +74,8 @@ class SpekTestEngine : TestEngine {
             filters.add(PathBuilder.ROOT)
         }
 
-        val discoveryResult = runtime.discover(DiscoveryRequest(DiscoveryContext(mapOf()), sourceDirs, filters.toList()))
+        val context = JvmDiscoveryContextFactory.create(sourceDirs)
+        val discoveryResult = runtime.discover(DiscoveryRequest(context, filters.toList()))
 
         discoveryResult.roots
             .map { descriptorFactory.create(it) }

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/launcher/ConsoleLauncher.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/launcher/ConsoleLauncher.kt
@@ -87,7 +87,7 @@ abstract class AbstractConsoleLauncher {
             paths.add(PathBuilder.ROOT)
         }
 
-        val discoveryRequest = DiscoveryRequest(context, emptyList(), paths)
+        val discoveryRequest = DiscoveryRequest(context, paths)
         val discoveryResult = runtime.discover(discoveryRequest)
 
         val listener = CompoundExecutionListener(listeners)

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/execution/Discovery.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/execution/Discovery.kt
@@ -4,5 +4,5 @@ import org.spekframework.spek2.runtime.discovery.DiscoveryContext
 import org.spekframework.spek2.runtime.scope.Path
 import org.spekframework.spek2.runtime.scope.ScopeImpl
 
-data class DiscoveryRequest(val context: DiscoveryContext, val sourceDirs: List<String>, val paths: List<Path>)
-data class DiscoveryResult(val roots: List<ScopeImpl>)
+class DiscoveryRequest(val context: DiscoveryContext, val paths: List<Path>)
+class DiscoveryResult(val roots: List<ScopeImpl>)

--- a/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/JvmDiscoveryContextFactory.kt
+++ b/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/JvmDiscoveryContextFactory.kt
@@ -1,0 +1,60 @@
+package org.spekframework.spek2.runtime
+
+import io.github.classgraph.ClassGraph
+import org.spekframework.spek2.CreateWith
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.lifecycle.InstanceFactory
+import org.spekframework.spek2.meta.Ignore
+import org.spekframework.spek2.runtime.discovery.DiscoveryContext
+import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.primaryConstructor
+import kotlin.streams.toList
+
+object JvmDiscoveryContextFactory {
+    private val defaultInstanceFactory = object : InstanceFactory {
+        override fun <T : Spek> create(spek: KClass<T>): T {
+            return spek.objectInstance ?: spek.constructors.first { it.parameters.isEmpty() }
+                .call()
+        }
+    }
+
+    fun create(testDirs: List<String>): DiscoveryContext {
+        val classes = scanClasses(testDirs)
+        val builder = DiscoveryContext.builder()
+
+        classes.filter { !it.isAbstract }
+            .filter { it.findAnnotation<Ignore>() == null }
+            .map { cls ->
+                val instanceFactory = instanceFactoryFor(cls)
+                cls to { instanceFactory.create(cls) }
+            }.forEach { (cls, factory) ->
+                builder.addTest(cls, factory)
+            }
+
+        return builder.build()
+    }
+
+    private fun instanceFactoryFor(spek: KClass<*>): InstanceFactory {
+        return spek.annotations.filterIsInstance<CreateWith>()
+            .map { it.factory }
+            .map { it.objectInstance ?: it.primaryConstructor!!.call() }
+            .firstOrNull() ?: defaultInstanceFactory
+    }
+
+    private fun scanClasses(testDirs: List<String>): List<KClass<out Spek>> {
+        val cg = ClassGraph()
+            .enableClassInfo()
+
+        if (testDirs.isNotEmpty()) {
+            cg.overrideClasspath(testDirs)
+        }
+
+        return cg.scan().use {
+            it.getSubclasses(Spek::class.qualifiedName!!).stream()
+                .map { it.loadClass() as Class<out Spek> }
+                .map { it.kotlin }
+                .toList()
+        }
+    }
+}

--- a/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/SpekJvmRuntime.kt
+++ b/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/SpekJvmRuntime.kt
@@ -1,70 +1,26 @@
 package org.spekframework.spek2.runtime
 
-import io.github.classgraph.ClassGraph
-import org.spekframework.spek2.CreateWith
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.lifecycle.InstanceFactory
-import org.spekframework.spek2.meta.Ignore
 import org.spekframework.spek2.runtime.execution.DiscoveryRequest
 import org.spekframework.spek2.runtime.execution.DiscoveryResult
-import org.spekframework.spek2.runtime.scope.PathBuilder
 import org.spekframework.spek2.runtime.scope.isRelated
-import kotlin.reflect.KClass
-import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.primaryConstructor
-import kotlin.streams.toList
 
 actual class SpekRuntime : AbstractRuntime() {
-    private val defaultInstanceFactory = object : InstanceFactory {
-        override fun <T : Spek> create(spek: KClass<T>): T {
-            return spek.objectInstance ?: spek.constructors.first { it.parameters.isEmpty() }
-                .call()
-        }
-    }
-
     override fun discover(discoveryRequest: DiscoveryRequest): DiscoveryResult {
-        val scopes = scanClasses(discoveryRequest.sourceDirs)
-            .filter { it.findAnnotation<Ignore>() == null }
-            .filter { !it.isAbstract }
-            .map { klass ->
-                klass to PathBuilder.from(klass).build()
+        val scopes = discoveryRequest.context.getTests()
+            .map { testInfo ->
+                val matchingPath = discoveryRequest.paths.firstOrNull { it.isRelated(testInfo.path) }
+                testInfo to matchingPath
             }
-            .map { (klass, path) ->
-                val matched = discoveryRequest.paths.firstOrNull { it.isRelated(path) }
-                val root = matched?.let {
-                    resolveSpec(instanceFactoryFor(klass).create(klass), path)
-                }
-                matched to root
+            .filter { (_, matchingPath) -> matchingPath != null }
+            .map { (testInfo, matchingPath) ->
+                checkNotNull(matchingPath)
+                val spec = resolveSpec(testInfo.createInstance(), testInfo.path)
+                spec.filterBy(matchingPath)
+                spec
             }
-            .filter { (path, root) -> path != null && root != null }
-            .map { (path, root) ->
-                root!!.apply { filterBy(path!!) }
-            }
-            .filter { !it.isEmpty() }
+            .filter { spec -> !spec.isEmpty() }
+
 
         return DiscoveryResult(scopes)
-    }
-
-    private fun instanceFactoryFor(spek: KClass<*>): InstanceFactory {
-        return spek.annotations.filterIsInstance<CreateWith>()
-            .map { it.factory }
-            .map { it.objectInstance ?: it.primaryConstructor!!.call() }
-            .firstOrNull() ?: defaultInstanceFactory
-    }
-
-    private fun scanClasses(testDirs: List<String>): List<KClass<out Spek>> {
-        val cg = ClassGraph()
-            .enableClassInfo()
-
-        if (testDirs.isNotEmpty()) {
-            cg.overrideClasspath(testDirs)
-        }
-
-        return cg.scan().use {
-            it.getSubclasses(Spek::class.qualifiedName!!).stream()
-                .map { it.loadClass() as Class<out Spek> }
-                .map { it.kotlin }
-                .toList()
-        }
     }
 }

--- a/spek-runtime/src/nativeMain/kotlin/org/spekframework/spek2/runtime/SpekNativeRuntime.kt
+++ b/spek-runtime/src/nativeMain/kotlin/org/spekframework/spek2/runtime/SpekNativeRuntime.kt
@@ -7,20 +7,20 @@ import org.spekframework.spek2.runtime.scope.isRelated
 
 actual class SpekRuntime : AbstractRuntime() {
     override fun discover(discoveryRequest: DiscoveryRequest): DiscoveryResult {
-        val scopes = discoveryRequest.context.classes
-                .mapKeys { (klass, _) -> PathBuilder.from(klass).build() }
-                .map { (path, factory) ->
-                    val matched = discoveryRequest.paths.firstOrNull { it.isRelated(path) }
-                    val root = matched?.let {
-                        resolveSpec(factory(), path)
-                    }
-                    matched to root
+        val scopes = discoveryRequest.context.getTests()
+            .map { it.path to { it.createInstance() } }
+            .map { (path, factory) ->
+                val matched = discoveryRequest.paths.firstOrNull { it.isRelated(path) }
+                val root = matched?.let {
+                    resolveSpec(factory(), path)
                 }
-                .filter { (path, root) -> path != null && root != null }
-                .map { (path, root) ->
-                    root!!.apply { filterBy(path!!) }
-                }
-                .filter { !it.isEmpty() }
+                matched to root
+            }
+            .filter { (path, root) -> path != null && root != null }
+            .map { (path, root) ->
+                root!!.apply { filterBy(path!!) }
+            }
+            .filter { !it.isEmpty() }
 
         return DiscoveryResult(scopes)
     }


### PR DESCRIPTION
resolves #608.

At this point we don't need platform specific versions of `SpekRuntime`, I'll work on a separate PR to merge the two implementations.

//cc: @charleskorn 