### PR TITLE
Dont add default package to path

### DIFF
--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/scope/Path.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/scope/Path.kt
@@ -91,17 +91,18 @@ class PathBuilder(private var parent: Path) {
 
         fun from(clz: KClass<*>): PathBuilder {
             val (packageName, className) = ClassUtil.extractPackageAndClassNames(clz)
-            return PathBuilder()
-                .append(packageName)
+            val builder = PathBuilder()
+            if (packageName.isNotEmpty()) {
+                builder.append(packageName)
+            }
+            return builder
                 .append(className)
         }
 
         fun parse(path: String): PathBuilder {
             var builder = PathBuilder()
 
-            // path string always starts with /
-            path.removePrefix("${Path.PATH_SEPARATOR}")
-                .split(Path.PATH_SEPARATOR)
+            path.split(Path.PATH_SEPARATOR)
                 .forEach { builder = builder.append(Path.decode(it)) }
 
             return builder


### PR DESCRIPTION
Made a boo-boo in my last PR. We don't add the default package (blank string) when building the path, but the previous PR did.