### PR TITLE
Create separate paths for every package part

### DIFF
--- a/spek-ide-plugin/intellij-base/src/main/kotlin/org/spekframework/intellij/domain/ScopeDescriptorCache.kt
+++ b/spek-ide-plugin/intellij-base/src/main/kotlin/org/spekframework/intellij/domain/ScopeDescriptorCache.kt
@@ -50,7 +50,7 @@ class ScopeDescriptorCache: ProjectComponent {
         val info = KtClassInfoUtil.createClassLikeInfo(clz)
         val builder = PathBuilder()
         if (info.containingPackageFqName.asString().isNotBlank()) {
-            builder.append(info.containingPackageFqName.asString())
+            builder.appendPackage(info.containingPackageFqName.asString())
         }
         val path = builder
             .append(checkNotNull(clz.fqName).shortName().asString())

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
@@ -56,7 +56,8 @@ class SpekTestEngine : TestEngine {
 
         val packageSelectors = discoveryRequest.getSelectorsByType(PackageSelector::class.java)
             .map {
-                PathBuilder().append(it.packageName)
+                PathBuilder()
+                    .appendPackage(it.packageName)
                     .build()
             }
 

--- a/spek-runner/junit5/src/test/kotlin/org/spekframework/spek2/junit/RunnerTests.kt
+++ b/spek-runner/junit5/src/test/kotlin/org/spekframework/spek2/junit/RunnerTests.kt
@@ -36,6 +36,23 @@ class RunnerTests {
     }
 
     @Test
+    fun testSelectPackageWithSubpackages() {
+        val listener = SummaryGeneratingListener()
+        launcher.execute(
+            LauncherDiscoveryRequestBuilder.request()
+                .filters(EngineFilter.includeEngines("spek2"))
+                .selectors(DiscoverySelectors.selectPackage("testData.package2"))
+                .build(),
+            listener
+        )
+
+        val summary = listener.summary
+
+        assertThat(summary.testsSucceededCount, equalTo(2L))
+    }
+
+
+    @Test
     fun testSelectClassDefaultPackage() {
         val listener = SummaryGeneratingListener()
         launcher.execute(

--- a/spek-runner/junit5/src/test/kotlin/testData/package2/subpackage1/TestInSubpackage1.kt
+++ b/spek-runner/junit5/src/test/kotlin/testData/package2/subpackage1/TestInSubpackage1.kt
@@ -1,0 +1,7 @@
+package testData.package2.subpackage1
+
+import org.spekframework.spek2.Spek
+
+object TestInSubpackage1: Spek({
+    test("this is a test") {}
+})

--- a/spek-runner/junit5/src/test/kotlin/testData/package2/subpackage2/TestInSubpackage2.kt
+++ b/spek-runner/junit5/src/test/kotlin/testData/package2/subpackage2/TestInSubpackage2.kt
@@ -1,0 +1,7 @@
+package testData.package2.subpackage2
+
+import org.spekframework.spek2.Spek
+
+object TestInSubpackage2: Spek({
+    test("this is a test") {}
+})

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/scope/Path.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/scope/Path.kt
@@ -79,6 +79,12 @@ data class Path(val name: String, val parent: Path?) {
 class PathBuilder(private var parent: Path) {
     constructor() : this(ROOT)
 
+    fun appendPackage(packageName: String): PathBuilder {
+        packageName.split('.')
+            .forEach { part -> append(part) }
+        return this
+    }
+
     fun append(name: String): PathBuilder {
         parent = Path(name, parent)
         return this
@@ -92,7 +98,7 @@ class PathBuilder(private var parent: Path) {
         fun from(clz: KClass<*>): PathBuilder {
             val (packageName, className) = ClassUtil.extractPackageAndClassNames(clz)
             return PathBuilder()
-                .append(packageName)
+                .appendPackage(packageName)
                 .append(className)
         }
 


### PR DESCRIPTION
Resolves #606.

Basically changes the path generation for package names.

`com.example/Foo` -> `com/example/Foo`