### PR TITLE
Refactor travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ git:
 jobs:
   include:
     - stage: build core
-      script: ./gradlew --stacktrace spek-dsl:build spek-runtime:build spek-runner:junit5:build integration-test:build
+      script: ./gradlew --stacktrace spek-dsl:build spek-runtime:build spek-runner:junit5:build integration-test:build -PexcludeIdePlugins
 
     - stage: build ide plugins
       script:
@@ -54,6 +54,8 @@ before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
   - rm -fr $HOME/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/unzipped.com.jetbrains.plugins
+  - rm -rf $HOME/.gradle/caches/modules-2/files-2.1/com.jetbrains/jbre
+  - rm -rf $HOME/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea
   - rm -fr $HOME/.konan/dependencies
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,12 @@ jobs:
       script: ./gradlew --stacktrace spek-dsl:build spek-runtime:build spek-runner:junit5:build integration-test:build
 
     - stage: build ide plugins
-      script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ182
-    - script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ183
-    - script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ191
-    - script: ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS33
-    - script: ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS34
+      script:
+        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ182
+        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ183
+        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ191
+        - ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS33
+        - ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS34
 
     - stage: release core
       script: ./gradlew --stacktrace spek-dsl:bintrayUpload spek-runtime:bintrayUpload spek-runner:junit5:bintrayUpload

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ stages:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -fr $HOME/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/unzipped.com.jetbrains.plugins
   - rm -fr $HOME/.konan/dependencies
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,15 @@ jobs:
         - ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS34
 
     - stage: release core
-      script: ./gradlew --stacktrace spek-dsl:bintrayUpload spek-runtime:bintrayUpload spek-runner:junit5:bintrayUpload
+      script: ./gradlew --stacktrace spek-dsl:bintrayUpload spek-runtime:bintrayUpload spek-runner:junit5:bintrayUpload -PexcludeIdePlugins
 
     - stage: release ide plugins
-      script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ182
-    - script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ183
-    - script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ191
-    - script: ./gradlew --stacktrace spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS33
-    - script: ./gradlew --stacktrace spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS34
+      script:
+        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ182
+        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ183
+        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ191
+        - ./gradlew --stacktrace spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS33
+        - ./gradlew --stacktrace spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS34
 
     - stage: update docs
       script: curl -X POST -d '' $NETLIFY_DEPLOY_URL

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ before_cache:
   - rm -fr $HOME/.konan/dependencies
 
 cache:
-  timeout: 360
   directories:
     - $HOME/.gradle
     - $HOME/.konan

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,22 +18,24 @@ jobs:
   include:
     - stage: build core
       script: ./gradlew --stacktrace spek-dsl:build spek-runtime:build spek-runner:junit5:build integration-test:build
+
     - stage: build ide plugins
-      script:
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ182
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ183
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ191
-        - ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS33
-        - ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS34
+      script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ182
+    - script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ183
+    - script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ191
+    - script: ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS33
+    - script: ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS34
+
     - stage: release core
       script: ./gradlew --stacktrace spek-dsl:bintrayUpload spek-runtime:bintrayUpload spek-runner:junit5:bintrayUpload
+
     - stage: release ide plugins
-      script:
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:clean spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ182
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:clean spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ183
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:clean spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ191
-        - ./gradlew --stacktrace spek-ide-plugin:android-studio:clean spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS33
-        - ./gradlew --stacktrace spek-ide-plugin:android-studio:clean spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS34
+      script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ182
+    - script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ183
+    - script: ./gradlew --stacktrace spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ191
+    - script: ./gradlew --stacktrace spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS33
+    - script: ./gradlew --stacktrace spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS34
+
     - stage: update docs
       script: curl -X POST -d '' $NETLIFY_DEPLOY_URL
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,12 @@ stages:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -fr $HOME/.konan/dependencies
 
 cache:
   directories:
     - $HOME/.gradle
+    - $HOME/.konan
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 
 language: java
-jdk: openjdk10
+jdk: openjdk11
 
 branches:
   only:
@@ -16,52 +16,38 @@ git:
 
 jobs:
   include:
-    - stage: build
+    - stage: build core
+      script: ./gradlew --stacktrace spek-dsl:build spek-runtime:build spek-runner:junit5:build integration-test:build
+    - stage: build ide plugins
       script:
-        - ./gradlew --stacktrace clean build
         - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ182
         - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ183
         - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ191
         - ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS33
         - ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS34
-    - stage: build-jdk11
+    - stage: release core
+      script: ./gradlew --stacktrace spek-dsl:bintrayUpload spek-runtime:bintrayUpload spek-runner:junit5:bintrayUpload
+    - stage: release ide plugins
       script:
-        - ./gradlew --stacktrace clean build
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ182
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ183
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:buildPlugin -Pij.version=IJ191
-        - ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS33
-        - ./gradlew --stacktrace spek-ide-plugin:android-studio:buildPlugin -Pas.version=AS34
-      jdk: openjdk11
-    - stage: release
-      script:
-        - ./gradlew --stacktrace bintrayUpload
         - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:clean spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ182
         - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:clean spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ183
         - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:clean spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ191
         - ./gradlew --stacktrace spek-ide-plugin:android-studio:clean spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS33
         - ./gradlew --stacktrace spek-ide-plugin:android-studio:clean spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS34
-        - curl -X POST -d '' $NETLIFY_DEPLOY_URL
-    - stage: release-dev
-      script:
-        - ./gradlew --stacktrace bintrayUpload
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:clean spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ182
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:clean spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ183
-        - ./gradlew --stacktrace spek-ide-plugin:intellij-idea:clean spek-ide-plugin:intellij-idea:publishPlugin -Pij.version=IJ191
-        - ./gradlew --stacktrace spek-ide-plugin:android-studio:clean spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS33
-        - ./gradlew --stacktrace spek-ide-plugin:android-studio:clean spek-ide-plugin:android-studio:publishPlugin -Pas.version=AS34
+    - stage: update docs
+      script: curl -X POST -d '' $NETLIFY_DEPLOY_URL
 
 stages:
-  - build
-  - build-jdk11
-  - name: release
+  - build core
+  - build ide plugins
+  - name: release core
+    if: type != pull_request AND repo = "spekframework/spek"
+  - name: release ide plugins
+    if: type != pull_request AND repo = "spekframework/spek"
+  - name: update docs
     if: tag IS present AND repo = "spekframework/spek"
-  - name: release-dev
-    if: tag IS NOT present AND type != pull_request AND repo = "spekframework/spek"
 
 before_cache:
-  - rm -rf $HOME/.gradle/caches/modules-2/files-2.1/com.jetbrains/jbre
-  - rm -rf $HOME/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ before_cache:
   - rm -fr $HOME/.konan/dependencies
 
 cache:
+  timeout: 360
   directories:
     - $HOME/.gradle
     - $HOME/.konan

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,8 +23,10 @@ include 'spek-runtime'
 include 'spek-runner:junit5'
 include 'integration-test'
 
-include 'spek-ide-plugin:interop-jvm'
-include 'spek-ide-plugin:intellij-base'
-include 'spek-ide-plugin:intellij-base-jvm'
-include 'spek-ide-plugin:intellij-idea'
-include 'spek-ide-plugin:android-studio'
+if (!hasProperty("excludeIdePlugins")) {
+    include 'spek-ide-plugin:interop-jvm'
+    include 'spek-ide-plugin:intellij-base'
+    include 'spek-ide-plugin:intellij-base-jvm'
+    include 'spek-ide-plugin:intellij-idea'
+    include 'spek-ide-plugin:android-studio'
+}


### PR DESCRIPTION
Split out the build into several stages:

- Build core (dsl, runtime and runners only - ide plugins are excluded via `-PexcludeIdePlugins`)
- Build ide plugins
- Release core (same as the build step) (main branch only)
- Release ide plugins (main branch only)
- Update docs (main branch only)

The `excludeIdePlugins` flag is hacky but it saves us `~4-5mins` build time. The `X ide plugins` stages can be parallelized if only `gradle-intellij-plugin` didn't download the IJ SDKs at gradle configuration time :disappointed: .