### PR TITLE
Don't include local classes

### DIFF
--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
@@ -49,7 +49,7 @@ class SpekTestEngine : TestEngine {
 
         val classSelectors = discoveryRequest.getSelectorsByType(ClassSelector::class.java)
             .filter {
-                it.javaClass.isLocalClass.not()
+                !(it.javaClass.isLocalClass || it.javaClass.isAnonymousClass)
             }.map {
                 PathBuilder
                     .from(it.javaClass.kotlin)

--- a/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
+++ b/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestEngine.kt
@@ -48,7 +48,9 @@ class SpekTestEngine : TestEngine {
             .map { it.toString() }
 
         val classSelectors = discoveryRequest.getSelectorsByType(ClassSelector::class.java)
-            .map {
+            .filter {
+                it.javaClass.isLocalClass.not()
+            }.map {
                 PathBuilder
                     .from(it.javaClass.kotlin)
                     .build()


### PR DESCRIPTION
Resolves #654.

[KClass#qualifiedName](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-class/qualified-name.html) returns null if the class is local or anonymous object literal but [`PathBuilder.from(KClass)`](https://github.com/spekframework/spek/blob/e7d76336473af50f8d9d1f116749a6a5a7bea43d/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/scope/Path.kt#L98) requires the `KClass#qualifiedName` returns non-null string so `SpekTestEngine` fails during test discovery.