### PR TITLE
Add eagerly evaluated memoized

### DIFF
--- a/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/dsl/dsl.kt
+++ b/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/dsl/dsl.kt
@@ -29,6 +29,9 @@ interface LifecycleAware : ScopeBody {
     fun <T> memoized(mode: CachingMode = defaultCachingMode, factory: () -> T): MemoizedValue<T>
     fun <T> memoized(mode: CachingMode = defaultCachingMode, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T>
 
+    fun <T> eagerMemoized(mode: CachingMode = defaultCachingMode, factory: () -> T): MemoizedValue<T>
+    fun <T> eagerMemoized(mode: CachingMode = defaultCachingMode, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T>
+
     fun beforeEachTest(callback: () -> Unit)
     fun afterEachTest(callback: () -> Unit)
 

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Collectors.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Collectors.kt
@@ -18,14 +18,27 @@ class Collector(
 
     private val ids = linkedMapOf<String, Int>()
 
-    override fun <T> memoized(mode: CachingMode, factory: () -> T): MemoizedValue<T> = memoized(mode, factory) { }
+    override fun <T> memoized(mode: CachingMode, factory: () -> T) = memoized(mode, factory) { }
 
     override fun <T> memoized(mode: CachingMode, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T> {
         return MemoizedValueCreator(
             root,
             mode,
             factory,
-            destructor
+            destructor,
+            eager = false
+        )
+    }
+
+    override fun <T> eagerMemoized(mode: CachingMode, factory: () -> T) = eagerMemoized(mode, factory) {  }
+
+    override fun <T> eagerMemoized(mode: CachingMode, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T> {
+        return MemoizedValueCreator(
+            root,
+            mode,
+            factory,
+            destructor,
+            eager = true
         )
     }
 

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Collectors.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Collectors.kt
@@ -21,24 +21,23 @@ class Collector(
     override fun <T> memoized(mode: CachingMode, factory: () -> T) = memoized(mode, factory) { }
 
     override fun <T> memoized(mode: CachingMode, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T> {
-        return MemoizedValueCreator(
-            root,
-            mode,
-            factory,
-            destructor,
-            eager = false
-        )
+        return createMemoized(mode, factory, destructor, eager = false)
     }
 
     override fun <T> eagerMemoized(mode: CachingMode, factory: () -> T) = eagerMemoized(mode, factory) {  }
 
     override fun <T> eagerMemoized(mode: CachingMode, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T> {
+        return createMemoized(mode, factory, destructor, eager = true)
+    }
+
+    private fun <T> createMemoized(mode: CachingMode, factory: () -> T, destructor: (T) -> Unit, eager: Boolean): MemoizedValue<T> {
         return MemoizedValueCreator(
-            root,
-            mode,
-            factory,
-            destructor,
-            eager = true
+            root = this,
+            scope = root,
+            mode = mode,
+            factory = factory,
+            destructor = destructor,
+            eager = eager
         )
     }
 

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/lifecycle/MemoizedValueCreator.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/lifecycle/MemoizedValueCreator.kt
@@ -1,5 +1,6 @@
 package org.spekframework.spek2.runtime.lifecycle
 
+import org.spekframework.spek2.dsl.Root
 import org.spekframework.spek2.lifecycle.CachingMode
 import org.spekframework.spek2.lifecycle.MemoizedValue
 import org.spekframework.spek2.runtime.scope.ScopeImpl
@@ -7,6 +8,7 @@ import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
 class MemoizedValueCreator<out T>(
+    private val root: Root,
     val scope: ScopeImpl,
     private val mode: CachingMode,
     val factory: () -> T,
@@ -20,9 +22,9 @@ class MemoizedValueCreator<out T>(
     ): ReadOnlyProperty<Any?, T> {
 
         val adapter = when (mode) {
-            CachingMode.GROUP -> MemoizedValueAdapter.GroupCachingModeAdapter(factory, destructor, eager)
-            CachingMode.TEST -> MemoizedValueAdapter.TestCachingModeAdapter(factory, destructor, eager)
-            CachingMode.SCOPE -> MemoizedValueAdapter.ScopeCachingModeAdapter(scope, factory, destructor, eager)
+            CachingMode.GROUP -> GroupCachingModeAdapter(factory, destructor)
+            CachingMode.TEST -> TestCachingModeAdapter(factory, destructor)
+            CachingMode.SCOPE -> ScopeCachingModeAdapter(scope, factory, destructor)
             CachingMode.INHERIT -> throw AssertionError("Not allowed.")
         }
 
@@ -30,6 +32,10 @@ class MemoizedValueCreator<out T>(
         scope.registerValue(property.name, adapter)
 
         return adapter.apply {
+            if (eager) {
+                registerEagerInitializer(root)
+            }
+
             scope.lifecycleManager.addListener(this)
         }
     }

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/lifecycle/MemoizedValueCreator.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/lifecycle/MemoizedValueCreator.kt
@@ -10,7 +10,8 @@ class MemoizedValueCreator<out T>(
     val scope: ScopeImpl,
     private val mode: CachingMode,
     val factory: () -> T,
-    private val destructor: (T) -> Unit
+    private val destructor: (T) -> Unit,
+    val eager: Boolean
 ) : MemoizedValue<T> {
 
     override operator fun provideDelegate(
@@ -19,9 +20,9 @@ class MemoizedValueCreator<out T>(
     ): ReadOnlyProperty<Any?, T> {
 
         val adapter = when (mode) {
-            CachingMode.GROUP -> MemoizedValueAdapter.GroupCachingModeAdapter(factory, destructor)
-            CachingMode.TEST -> MemoizedValueAdapter.TestCachingModeAdapter(factory, destructor)
-            CachingMode.SCOPE -> MemoizedValueAdapter.ScopeCachingModeAdapter(scope, factory, destructor)
+            CachingMode.GROUP -> MemoizedValueAdapter.GroupCachingModeAdapter(factory, destructor, eager)
+            CachingMode.TEST -> MemoizedValueAdapter.TestCachingModeAdapter(factory, destructor, eager)
+            CachingMode.SCOPE -> MemoizedValueAdapter.ScopeCachingModeAdapter(scope, factory, destructor, eager)
             CachingMode.INHERIT -> throw AssertionError("Not allowed.")
         }
 


### PR DESCRIPTION
This PR adds a new type of `memoized` values that are eagerly evaluated. The goal of this PR is the fix the issues presented in #658 and #645. Tests still needs to be added, and I'd greatly appreciate some help with help how to properly test this feature.

The code works so far that values are eagerly evaluated for each test, however I discovered that the order in which they are evaluated is reversed. I found this is because the `LifecycleListener` for each memoized value being [*prepended* to the list of listeners](https://github.com/spekframework/spek/blob/2.x/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/lifecycle/LifecycleManager.kt#L17). I'm hesitant to changing this to appending the listeners, as I'm not sure if it will break existing code relying on Spek. Additionally all fixtures are grouped together in a single listener, that's always invoked last. This means you can't mix fixtures before or between eager memoized.

The following code should help illustrate the ordering issue. A user might expect the printed result to be `A2C1B3`, but because of the implementation details describe above the actual result is `BCA213`.
```kotlin
val a by eagerMemoized { print("A") }
beforeEach {             print("2") }
val c by eagerMemoized { print("C") }
beforeEach {             print("1") }
val b by eagerMemoized { print("B") }
beforeEach {             print("3") }
```