### PR TITLE
Add NATIVE and JS producer types in IJ

### DIFF
--- a/spek-ide-plugin/intellij-base/src/main/kotlin/org/spekframework/intellij/producerType.kt
+++ b/spek-ide-plugin/intellij-base/src/main/kotlin/org/spekframework/intellij/producerType.kt
@@ -2,17 +2,23 @@ package org.spekframework.intellij
 
 import org.jetbrains.kotlin.platform.IdePlatformKind
 import org.jetbrains.kotlin.platform.impl.CommonIdePlatformKind
+import org.jetbrains.kotlin.platform.impl.JsIdePlatformKind
 import org.jetbrains.kotlin.platform.impl.JvmIdePlatformKind
+import org.jetbrains.kotlin.platform.impl.NativeIdePlatformKind
 
 enum class ProducerType {
     COMMON,
-    JVM
+    JVM,
+    NATIVE,
+    JS
 }
 
 fun IdePlatformKind<*>.toProducerType(): ProducerType {
     return when (this) {
         CommonIdePlatformKind -> ProducerType.COMMON
         JvmIdePlatformKind -> ProducerType.JVM
+        NativeIdePlatformKind -> ProducerType.NATIVE
+        JsIdePlatformKind -> ProducerType.JS
         else -> throw IllegalArgumentException("Unsupported platform kind: ${this}")
     }
 }


### PR DESCRIPTION
Note that running tests for Native and JS in IJ is not yet supported.

Resolves #704 