### PR TITLE
Support IntelliJ IDEA 2019.2 EAP

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,9 +10,9 @@ repositories {
 }
 
 dependencies {
-    api(kotlin("gradle-plugin", version = "1.3.30"))
+    api(kotlin("gradle-plugin", version = "1.3.31"))
     api("org.jetbrains.dokka:dokka-gradle-plugin:0.9.17")
     api("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
-    api("gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.8")
+    api("gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.9")
     api("com.github.jengelman.gradle.plugins:shadow:4.0.2")
 }

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -25,11 +25,18 @@ val buildMatrix = mapOf(
         "IJ2019.1",
         "IJ183",
         ij.VersionRange("191.1", "191.*"),
-        arrayOf("org.jetbrains.kotlin:1.3.30-release-IJ2019.1-1")
+        arrayOf("org.jetbrains.kotlin:1.3.31-release-IJ2019.1-1")
+    ),
+    "IJ192" to ij.BuildConfig(
+        "192-EAP-SNAPSHOT",
+        "IJ2019.2",
+        "IJ183",
+        ij.VersionRange("192.1", "192.*"),
+        arrayOf("java", "org.jetbrains.kotlin:1.3.40-release-IJ2019.2-1")
     )
 )
 
-val sdkVersion = project.properties["ij.version"] ?: "IJ191"
+val sdkVersion = project.properties["ij.version"] ?: "IJ192"
 val settings = checkNotNull(buildMatrix[sdkVersion])
 
 intellij {


### PR DESCRIPTION
resolves #732. Also bumps kotlin to `1.3.31` since there is no kotlin `1.3.30` plugin build for IJ192.