### PR TITLE
Allow running from packages

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -11,10 +11,13 @@ To run tests in IntelliJ IDEA or Android Studio you need to install [Spek Framew
 
 The plugin will allow you to:
 
-- Run all tests in a package (there should be an option under `Run` -> `Spek tests in <package>` when right clicking a package in the explorer)
+- Run all tests in a package (there should be an option under `Run` -> `Spek(s): <package>` when right clicking a package in the explorer)
 - Run specific scope via the gutter icons.
   ![gutter_icons](./images/gutter_icons.png)
 - See at a glance failed tests from the reporting window.
   ![test_tree](./images/test-tree.png)
 - Navigate to the failing test via the test tree (Right click the failing entry then `Jump to Source` or press `F4`). Do note that
   `Jump to Source` does not work if you run all tests within a package. 
+  
+When using [Gradle](https://gradle.org), please set `Build Tools/Gradle/Run tests using:` to `Intellij IDEA`. You can use `Choose per test` to show
+all possible options. 

--- a/spek-ide-plugin-intellij-base/src/main/kotlin/org/spekframework/intellij/SpekRunConfiguration.kt
+++ b/spek-ide-plugin-intellij-base/src/main/kotlin/org/spekframework/intellij/SpekRunConfiguration.kt
@@ -46,12 +46,10 @@ interface SpekRunConfiguration<T: SpekCommonProgramRunConfigurationParameters>: 
             "($it)"
         } ?: ""
 
-        return if (path.name.isEmpty() && parent != null && parent.isRoot) {
-            "$prefix Spek tests in <default package>"
-        } else if (parent != null && parent.isRoot) {
-            "$prefix Spek tests in ${path.name}"
+        return if (path.isRoot) {
+            "$prefix Speks in <default package>"
         } else {
-            "$prefix ${path.name}"
+            "Spek(s): ${path.toString()}"
         }.trim()
     }
 }


### PR DESCRIPTION
Resolves #750 and resolves #763.

An important note here is that `Build Tools -> Gradle -> Run tests using:` must be set to `IntelliJ IDEA` (platform test runner in older IJ versions) or `Choose per test` - if you won't set this IntellIJ will filter out the run configuration created by the spek plugin. Running tests via gradle will not be supported. You still have control if you want to build using IntelliJ or Gradle.