### PR TITLE
Allow a way to disable timeouts

### DIFF
--- a/integration-test/src/jvmTest/kotlin/org/spekframework/spek2/TimeoutTest.kt
+++ b/integration-test/src/jvmTest/kotlin/org/spekframework/spek2/TimeoutTest.kt
@@ -4,8 +4,7 @@ import org.spekframework.spek2.style.specification.describe
 
 object TimeoutTest: AbstractSpekTest({ helper ->
     describe("test timeouts") {
-        // FIXME: provide a way to disable timeouts.
-        it("should timeout using default settings", timeout = 60000L) {
+        it("should timeout using default settings", timeout = 0) {
             val recorder = helper.executeTest(testData.timeoutTest.DefaultTimeoutTest)
 
             helper.assertExecutionEquals(
@@ -49,8 +48,8 @@ object TimeoutTest: AbstractSpekTest({ helper ->
     }
 
     describe("global timeouts") {
-        it("should use specified global timeout", timeout = 120000) {
-            System.setProperty("SPEK_TIMEOUT", 20000L.toString())
+        it("should use specified global timeout", timeout = 0) {
+            System.setProperty("SPEK_TIMEOUT", 15000L.toString())
             val recorder = helper.executeTest(testData.timeoutTest.GlobalTimeoutTest)
 
             helper.assertExecutionEquals(

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Executor.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Executor.kt
@@ -74,12 +74,21 @@ class Executor {
                                 scope.execute()
                             }
 
-                            val exception = withTimeout(scope.timeout) {
+                            val exception = if (scope.timeout == 0L) {
                                 try {
                                     job.await()
                                     null
                                 } catch (e: Throwable) {
                                     e
+                                }
+                            } else {
+                                withTimeout(scope.timeout) {
+                                    try {
+                                        job.await()
+                                        null
+                                    } catch (e: Throwable) {
+                                        e
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
Resolves #792. 

Setting the timeout to `0` per scope or globally (`SPEK_TIMEOUT`) will now disable timeouts.