### PR TITLE
Add IDE inspection when a spek has no no-arg constructor

### DIFF
--- a/spek-ide-plugin-android-studio/src/main/resources/META-INF/plugin.xml
+++ b/spek-ide-plugin-android-studio/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,18 @@
         <runConfigurationProducer implementation="org.spekframework.intellij.SpekAndroidRunConfigurationProducer"/>
         <implicitUsageProvider implementation="org.spekframework.intellij.SpekImplicitUsageProvider"/>
         <runLineMarkerContributor language="kotlin" implementationClass="org.spekframework.intellij.SpekRunLineMarkerContributor"/>
+        <localInspection
+                language="kotlin"
+                displayName="Spek class needs no-arg constructor"
+                groupPath="Kotlin"
+                groupName="Spek"
+                groupKey="group.names.probable.bugs"
+                enabledByDefault="true"
+                level="WARNING"
+
+                implementationClass="org.spekframework.intellij.inspections.NoArgConstructorInspection"
+        />
+
     </extensions>
 
     <extensionPoints>

--- a/spek-ide-plugin-android-studio/src/main/resources/inspectionDescriptions/NoArgConstructor.html
+++ b/spek-ide-plugin-android-studio/src/main/resources/inspectionDescriptions/NoArgConstructor.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+This inspection reports classes inheriting from Spek, which do not have a no-arg constructor.
+Running spek would cause an error, because Spek does not know how to make Test Instances for this class.
+</body>
+</html>

--- a/spek-ide-plugin-intellij-base/src/main/kotlin/org/spekframework/intellij/inspections/NoArgConstructorInspection.kt
+++ b/spek-ide-plugin-intellij-base/src/main/kotlin/org/spekframework/intellij/inspections/NoArgConstructorInspection.kt
@@ -1,0 +1,63 @@
+/**
+ *@author Nikolaus Knop
+ */
+
+package org.spekframework.intellij.inspections
+
+import com.intellij.codeInspection.*
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.idea.inspections.AbstractKotlinInspection
+import org.jetbrains.kotlin.idea.refactoring.pullUp.makeAbstract
+import org.jetbrains.kotlin.idea.util.addAnnotation
+import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
+
+class NoArgConstructorInspection : AbstractKotlinInspection() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+        object : KtTreeVisitorVoid() {
+            override fun visitClass(klass: KtClass) {
+                val isSpek = klass.getSuperNames().any { it == "Spek" }
+                if (!isSpek) return
+                val ignored = klass.annotationEntries.any { it.shortName?.toString() == "Ignore" }
+                if (ignored) return
+                val modifiers = klass.modifierList
+                val isAbstract = modifiers != null && modifiers.hasModifier(ABSTRACT)
+                if (isAbstract) return
+                val hasCreateWith = klass.annotationEntries.any { it.shortName?.toString() == "CreateWith" }
+                if (hasCreateWith) return
+                val hasNoArgConstructor = klass.allConstructors.any { constr ->
+                    constr.getValueParameters().all { param -> param.hasDefaultValue() }
+                }
+                if (hasNoArgConstructor) return
+                val name = klass.nameIdentifier ?: return
+                holder.registerProblem(name, "Class #ref needs no-arg constructor #loc", IgnoreTest, MakeAbstract)
+            }
+        }
+
+    private object MakeAbstract : LocalQuickFix {
+        override fun getFamilyName(): String = "Make test class abstract"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val cls = descriptor.psiElement.parent as? KtClass ?: return
+            cls.makeAbstract()
+        }
+    }
+
+    private object IgnoreTest : LocalQuickFix {
+        override fun getFamilyName(): String = "Ignore this test"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val cls = descriptor.psiElement.parent as? KtClass ?: return
+            cls.addAnnotation(FqName(IGNORE))
+        }
+    }
+
+    companion object {
+        private const val IGNORE = "org.spekframework.spek2.meta.Ignore"
+        private val ABSTRACT = KtModifierKeywordToken.softKeywordModifier("abstract")
+    }
+}

--- a/spek-ide-plugin-intellij-idea/src/main/resources/META-INF/plugin.xml
+++ b/spek-ide-plugin-intellij-idea/src/main/resources/META-INF/plugin.xml
@@ -13,7 +13,19 @@
         <configurationType implementation="org.spekframework.intellij.SpekJvmConfigurationType"/>
         <runConfigurationProducer implementation="org.spekframework.intellij.SpekJvmRunConfigurationProducer"/>
         <implicitUsageProvider implementation="org.spekframework.intellij.SpekImplicitUsageProvider"/>
-        <runLineMarkerContributor language="kotlin" implementationClass="org.spekframework.intellij.SpekRunLineMarkerContributor"/>
+        <runLineMarkerContributor language="kotlin"
+                                  implementationClass="org.spekframework.intellij.SpekRunLineMarkerContributor"/>
+        <localInspection
+                language="kotlin"
+                displayName="Spek class needs no-arg constructor"
+                groupPath="Kotlin"
+                groupName="Spek"
+                groupKey="group.names.probable.bugs"
+                enabledByDefault="true"
+                level="WARNING"
+
+                implementationClass="org.spekframework.intellij.inspections.NoArgConstructorInspection"
+        />
     </extensions>
 
     <extensionPoints>

--- a/spek-ide-plugin-intellij-idea/src/main/resources/inspectionDescriptions/NoArgConstructor.html
+++ b/spek-ide-plugin-intellij-idea/src/main/resources/inspectionDescriptions/NoArgConstructor.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+This inspection reports classes inheriting from Spek, which do not have a no-arg constructor.
+Running spek would cause an error, because Spek does not know how to make Test Instances for this class.
+</body>
+</html>


### PR DESCRIPTION
Sorry, I'm pretty inexperienced with the general contribution process. 
So here is my pull request.
The pull request introduces a new Inspection, detecting Spek classes without no-arg constructors (Constructors, where all parameters have default values are considered no-arg as well). 
In general, the wording may be improved a little bit since I am not really proficient in English. 
- The name of the Inspection class could be improved
- The wording in the message of the Inspection could be better
I tested the Inspection locally and it seems to work reliably (including check for @Ignore or abstract classes). Two quickfixes are provided, one making the class abstract and one adding the `@Ignore` annotation.
I observed that the `plugin.xml` files are duplicated for the `spek-ide-plugin-intellij-idea` and `spek-ide-plugin-intellij-android-studio` modules. So I added the configuration in both files. Maybe it would make sense to at least extract some common parts out of it, although I don't really know how to do it.

Resolves #806 