### PR TITLE
Fixing typo in the core concepts page

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -166,12 +166,12 @@ The created objects can then be referenced by name.
 // Put the common logic here
 fun Root.setup() {
     val obj by memoized(
-        factory = { createObj() }
+        factory = { createObj() },
         destructor = { it.dispose() }
     )
 }
 
-objects Test: Spek({
+object Test: Spek({
    setup()
    
    // Fetches the object keyed by name 'obj'


### PR DESCRIPTION
Found some issues in the sample code snippet, while going through the docs. Fixed it.