### PR TITLE
Add support for RSpec `let`-style contextually overridable values.

### DIFF
--- a/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueMetaSpec.kt
+++ b/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueMetaSpec.kt
@@ -34,7 +34,7 @@ object LetValueMetaSpec : AbstractSpekTest({ helper ->
 
             val (_, result) = results.afterExecuteGroupResults.single()
             result as ExecutionResult.Failure
-            expect("letValue() can't be used from beforeEachGroup or afterEachGroup") { result.cause.message }
+            expect("letValue can't be used from beforeEachGroup or afterEachGroup") { result.cause.message }
         }
 
         it("should fail silently when invoked in afterEachGroup, cuz spek") {
@@ -45,7 +45,7 @@ object LetValueMetaSpec : AbstractSpekTest({ helper ->
             result as ExecutionResult.Success
             expect(listOf(
                     "afterEachGroup called",
-                    "letValue() failed: letValue() can't be used from beforeEachGroup or afterEachGroup"
+                    "letValue() failed: letValue can't be used from beforeEachGroup or afterEachGroup"
             )) { events }
         }
     }
@@ -54,7 +54,7 @@ object LetValueMetaSpec : AbstractSpekTest({ helper ->
 class LetValueInvokedFromBeforeEachGroupExample(private val listener: LifecycleListener) : Spek({
     registerListener(listener)
     val letValue by value { "anything" }
-    beforeEachGroup { letValue() }
+    beforeEachGroup { letValue.capitalize() }
     test("empty test") {}
 })
 
@@ -66,7 +66,8 @@ class LetValueInvokedFromAfterEachGroupExample(
     afterEachGroup {
         events.add("afterEachGroup called")
         try {
-            letValue()
+            // captitalize() so static analysis won't try to make this go away:
+            letValue.capitalize()
             events.add("letValue() called")
         } catch (e: Exception) {
             events.add("letValue() failed: ${e.message}")
@@ -79,7 +80,7 @@ class LetValueInvokedFromBeforeEachTestExample(private val listener: LifecycleLi
     registerListener(listener)
     val letValue by value { "anything" }
     beforeEachTest {
-        expect("anything") { letValue() }
+        expect("anything") { letValue }
     }
     test("empty test") {}
 })
@@ -88,7 +89,7 @@ class LetValueInvokedFromAfterEachTestExample(private val listener: LifecycleLis
     registerListener(listener)
     val letValue by value { "anything" }
     afterEachTest {
-        expect("anything") { letValue() }
+        expect("anything") { letValue }
     }
     test("empty test") {}
 })

--- a/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueMetaSpec.kt
+++ b/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueMetaSpec.kt
@@ -1,0 +1,117 @@
+package com.bushelpowered.slack_integrations
+
+import org.spekframework.spek2.AbstractSpekTest
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.lifecycle.ExecutionResult
+import org.spekframework.spek2.lifecycle.GroupScope
+import org.spekframework.spek2.lifecycle.LifecycleListener
+import org.spekframework.spek2.lifecycle.TestScope
+import org.spekframework.spek2.style.specification.describe
+import kotlin.test.expect
+
+object LetValueMetaSpec : AbstractSpekTest({ helper ->
+    val results by memoized { Results() }
+
+    describe("let values used correctly") {
+        it("should have the correct value when invoked in beforeEachTest") {
+            helper.executeTest(LetValueInvokedFromBeforeEachTestExample(results))
+
+            val (_, result) = results.afterExecuteTestResults.single()
+            expect(ExecutionResult.Success) { result }
+        }
+
+        it("should have the correct value when invoked in afterEachTest") {
+            helper.executeTest(LetValueInvokedFromAfterEachTestExample(results))
+
+            val (_, result) = results.afterExecuteTestResults.single()
+            expect(ExecutionResult.Success) { result }
+        }
+    }
+
+    describe("let values used incorrectly") {
+        it("should fail when invoked in beforeEachGroup") {
+            helper.executeTest(LetValueInvokedFromBeforeEachGroupExample(results))
+
+            val (_, result) = results.afterExecuteGroupResults.single()
+            result as ExecutionResult.Failure
+            expect("letValue() can't be used from beforeEachGroup or afterEachGroup") { result.cause.message }
+        }
+
+        it("should fail silently when invoked in afterEachGroup, cuz spek") {
+            val events = arrayListOf<String>()
+            helper.executeTest(LetValueInvokedFromAfterEachGroupExample(results, events))
+
+            val (_, result) = results.afterExecuteTestResults.single()
+            result as ExecutionResult.Success
+            expect(listOf(
+                    "afterEachGroup called",
+                    "letValue() failed: letValue() can't be used from beforeEachGroup or afterEachGroup"
+            )) { events }
+        }
+    }
+})
+
+class LetValueInvokedFromBeforeEachGroupExample(private val listener: LifecycleListener) : Spek({
+    registerListener(listener)
+    val letValue by value { "anything" }
+    beforeEachGroup { letValue() }
+    test("empty test") {}
+})
+
+class LetValueInvokedFromAfterEachGroupExample(
+        private val listener: LifecycleListener, val events: MutableList<String>
+) : Spek({
+    registerListener(listener)
+    val letValue by value { "anything" }
+    afterEachGroup {
+        events.add("afterEachGroup called")
+        try {
+            letValue()
+            events.add("letValue() called")
+        } catch (e: Exception) {
+            events.add("letValue() failed: ${e.message}")
+        }
+    }
+    test("empty test") {}
+})
+
+class LetValueInvokedFromBeforeEachTestExample(private val listener: LifecycleListener) : Spek({
+    registerListener(listener)
+    val letValue by value { "anything" }
+    beforeEachTest {
+        expect("anything") { letValue() }
+    }
+    test("empty test") {}
+})
+
+class LetValueInvokedFromAfterEachTestExample(private val listener: LifecycleListener) : Spek({
+    registerListener(listener)
+    val letValue by value { "anything" }
+    afterEachTest {
+        expect("anything") { letValue() }
+    }
+    test("empty test") {}
+})
+
+class Results : LifecycleListener {
+    val beforeExecuteTestResults = mutableListOf<TestScope>()
+    val afterExecuteTestResults = mutableListOf<Pair<TestScope, ExecutionResult>>()
+    val beforeExecuteGroupResults = mutableListOf<GroupScope>()
+    val afterExecuteGroupResults = mutableListOf<Pair<GroupScope, ExecutionResult>>()
+
+    override fun beforeExecuteTest(test: TestScope) {
+        beforeExecuteTestResults.add(test)
+    }
+
+    override fun afterExecuteTest(test: TestScope, result: ExecutionResult) {
+        afterExecuteTestResults.add(test to result)
+    }
+
+    override fun beforeExecuteGroup(group: GroupScope) {
+        beforeExecuteGroupResults.add(group)
+    }
+
+    override fun afterExecuteGroup(group: GroupScope, result: ExecutionResult) {
+        afterExecuteGroupResults.add(group to result)
+    }
+}

--- a/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueSpec.kt
+++ b/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueSpec.kt
@@ -37,6 +37,18 @@ object LetValueSpec : Spek({
             expect(listOf("1 base")) { anotherList() }
         }
 
+        describe("evaluation of values") {
+            var string = ""
+            val valueWithString by value { "with $string" }
+
+            beforeEachTest { string = "initial value" }
+
+            it("should be lazy") {
+                string = "modified value"
+                expect("with modified value") { valueWithString() }
+            }
+        }
+
         context("in another context") {
             beforeEachTest { anotherList().add("2A ${str()}") }
 

--- a/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueSpec.kt
+++ b/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueSpec.kt
@@ -12,29 +12,29 @@ object LetValueSpec : Spek({
         val list by value { mutableListOf<String>() }
         val anotherList by value { mutableListOf<String>() }
 
-        beforeEachTest { anotherList().add("1 ${str()}") }
+        beforeEachTest { anotherList.add("1 $str") }
 
         it("should permit values to be declared at the top level") {
-            expect("top level value") { topLevelValue() }
+            expect("top level value") { topLevelValue }
         }
 
         it("should memoized the value within a single test") {
-            list().add("a string")
-            list().add("another string")
+            list.add("a string")
+            list.add("another string")
 
-            expect(listOf("a string", "another string")) { list() }
+            expect(listOf("a string", "another string")) { list }
         }
 
         it("should regenerate the value for every test") {
-            expect(emptyList<String>()) { list() }
+            expect(emptyList<String>()) { list }
         }
 
         it("should return the specified value for this context") {
-            expect("base") { str() }
+            expect("base") { str }
         }
 
         it("should use context values in befores") {
-            expect(listOf("1 base")) { anotherList() }
+            expect(listOf("1 base")) { anotherList }
         }
 
         describe("evaluation of values") {
@@ -45,35 +45,35 @@ object LetValueSpec : Spek({
 
             it("should be lazy") {
                 string = "modified value"
-                expect("with modified value") { valueWithString() }
+                expect("with modified value") { valueWithString }
             }
         }
 
         context("in another context") {
-            beforeEachTest { anotherList().add("2A ${str()}") }
+            beforeEachTest { anotherList.add("2A $str") }
 
             value(str) { "xyz context" }
 
-            beforeEachTest { anotherList().add("2B ${str()}") }
+            beforeEachTest { anotherList.add("2B $str") }
 
             it("should return the value for that context") {
-                expect("xyz context") { str() }
+                expect("xyz context") { str }
             }
 
             it("should use context-overridden values in outer befores") {
-                expect(listOf("1 xyz context", "2A xyz context", "2B xyz context")) { anotherList() }
+                expect(listOf("1 xyz context", "2A xyz context", "2B xyz context")) { anotherList }
             }
         }
 
         it("should return the correct value after a nested context override") {
-            expect("base") { str() }
+            expect("base") { str }
         }
 
         context("with nullable values") {
             val nullable by value { null }
 
             it("can return null") {
-                expect(null) { nullable() }
+                expect(null) { nullable }
             }
         }
     }

--- a/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueSpec.kt
+++ b/integration-test/src/commonTest/kotlin/org/spekframework/spek2/integration/LetValueSpec.kt
@@ -1,0 +1,68 @@
+package org.spekframework.spek2.integration
+
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import kotlin.test.expect
+
+object LetValueSpec : Spek({
+    val topLevelValue by value { "top level value" }
+
+    describe("let variables") {
+        val str by value { "base" }
+        val list by value { mutableListOf<String>() }
+        val anotherList by value { mutableListOf<String>() }
+
+        beforeEachTest { anotherList().add("1 ${str()}") }
+
+        it("should permit values to be declared at the top level") {
+            expect("top level value") { topLevelValue() }
+        }
+
+        it("should memoized the value within a single test") {
+            list().add("a string")
+            list().add("another string")
+
+            expect(listOf("a string", "another string")) { list() }
+        }
+
+        it("should regenerate the value for every test") {
+            expect(emptyList<String>()) { list() }
+        }
+
+        it("should return the specified value for this context") {
+            expect("base") { str() }
+        }
+
+        it("should use context values in befores") {
+            expect(listOf("1 base")) { anotherList() }
+        }
+
+        context("in another context") {
+            beforeEachTest { anotherList().add("2A ${str()}") }
+
+            value(str) { "xyz context" }
+
+            beforeEachTest { anotherList().add("2B ${str()}") }
+
+            it("should return the value for that context") {
+                expect("xyz context") { str() }
+            }
+
+            it("should use context-overridden values in outer befores") {
+                expect(listOf("1 xyz context", "2A xyz context", "2B xyz context")) { anotherList() }
+            }
+        }
+
+        it("should return the correct value after a nested context override") {
+            expect("base") { str() }
+        }
+
+        context("with nullable values") {
+            val nullable by value { null }
+
+            it("can return null") {
+                expect(null) { nullable() }
+            }
+        }
+    }
+})

--- a/integration-test/src/jvmTest/kotlin/org/spekframework/spek2/FakeGroupBody.kt
+++ b/integration-test/src/jvmTest/kotlin/org/spekframework/spek2/FakeGroupBody.kt
@@ -6,6 +6,7 @@ import org.spekframework.spek2.dsl.GroupBody
 import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.dsl.TestBody
 import org.spekframework.spek2.lifecycle.CachingMode
+import org.spekframework.spek2.lifecycle.LetValue
 import org.spekframework.spek2.lifecycle.MemoizedValue
 
 class FakeGroupBody : GroupBody {
@@ -26,6 +27,12 @@ class FakeGroupBody : GroupBody {
             throw UnsupportedOperationException()
 
     override fun <T> memoized(mode: CachingMode, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T> =
+            throw UnsupportedOperationException()
+
+    override fun <T> value(factory: () -> T): LetValue.PropertyCreator<T> =
+            throw UnsupportedOperationException()
+
+    override fun <T> value(letValue: LetValue<T>, factory: () -> T) =
             throw UnsupportedOperationException()
 
     override fun beforeEachTest(fixture: Fixture) {

--- a/integration-test/src/jvmTest/kotlin/org/spekframework/spek2/FakeGroupBody.kt
+++ b/integration-test/src/jvmTest/kotlin/org/spekframework/spek2/FakeGroupBody.kt
@@ -32,7 +32,7 @@ class FakeGroupBody : GroupBody {
     override fun <T> value(factory: () -> T): LetValue.PropertyCreator<T> =
             throw UnsupportedOperationException()
 
-    override fun <T> value(letValue: LetValue<T>, factory: () -> T) =
+    override fun <T> value(letValue: T, factory: () -> T) =
             throw UnsupportedOperationException()
 
     override fun beforeEachTest(fixture: Fixture) {

--- a/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/dsl/dsl.kt
+++ b/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/dsl/dsl.kt
@@ -5,6 +5,7 @@ import org.spekframework.spek2.lifecycle.LifecycleListener
 import org.spekframework.spek2.lifecycle.MemoizedValue
 import org.spekframework.spek2.meta.*
 import org.spekframework.spek2.Spek
+import org.spekframework.spek2.lifecycle.LetValue
 
 sealed class Skip {
     class Yes(val reason: String? = null) : Skip()
@@ -32,6 +33,9 @@ interface LifecycleAware : ScopeBody {
 
     fun <T> memoized(mode: CachingMode = defaultCachingMode, factory: () -> T): MemoizedValue<T>
     fun <T> memoized(mode: CachingMode = defaultCachingMode, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T>
+
+    fun <T> value(factory: () -> T): LetValue.PropertyCreator<T>
+    fun <T> value(letValue: LetValue<T>, factory: () -> T)
 
     fun beforeEachTest(fixture: Fixture)
     fun afterEachTest(fixture: Fixture)

--- a/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/dsl/dsl.kt
+++ b/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/dsl/dsl.kt
@@ -35,7 +35,7 @@ interface LifecycleAware : ScopeBody {
     fun <T> memoized(mode: CachingMode = defaultCachingMode, factory: () -> T, destructor: (T) -> Unit): MemoizedValue<T>
 
     fun <T> value(factory: () -> T): LetValue.PropertyCreator<T>
-    fun <T> value(letValue: LetValue<T>, factory: () -> T)
+    fun <T> value(letValue: T, factory: () -> T)
 
     fun beforeEachTest(fixture: Fixture)
     fun afterEachTest(fixture: Fixture)

--- a/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/lifecycle/LetValue.kt
+++ b/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/lifecycle/LetValue.kt
@@ -7,6 +7,6 @@ interface LetValue<out T>: ReadOnlyProperty<Any?, LetValue<T>> {
     operator fun invoke(): T
 
     interface PropertyCreator<out T> {
-        operator fun provideDelegate(thisRef: Any?, property: KProperty<*>): ReadOnlyProperty<Any?, LetValue<T>>
+        operator fun provideDelegate(thisRef: Any?, property: KProperty<*>): ReadOnlyProperty<Any?, T>
     }
 }

--- a/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/lifecycle/LetValue.kt
+++ b/spek-dsl/src/commonMain/kotlin/org/spekframework/spek2/lifecycle/LetValue.kt
@@ -1,0 +1,12 @@
+package org.spekframework.spek2.lifecycle
+
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+interface LetValue<out T>: ReadOnlyProperty<Any?, LetValue<T>> {
+    operator fun invoke(): T
+
+    interface PropertyCreator<out T> {
+        operator fun provideDelegate(thisRef: Any?, property: KProperty<*>): ReadOnlyProperty<Any?, LetValue<T>>
+    }
+}

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Collectors.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Collectors.kt
@@ -67,8 +67,8 @@ class Collector(
         return LetValueCreator(factory, this, { finalizers.add(it) })
     }
 
-    override fun <T> value(letValue: LetValue<T>, factory: () -> T) {
-        (letValue as LetValueHolder).override(root.path, factory)
+    override fun <T> value(letValue: T, factory: () -> T) {
+        LetValueGetter.override(root.path, factory)
     }
 
     override fun registerListener(listener: LifecycleListener) {

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Collectors.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/Collectors.kt
@@ -2,9 +2,7 @@ package org.spekframework.spek2.runtime
 
 import org.spekframework.spek2.dsl.*
 import org.spekframework.spek2.lifecycle.*
-import org.spekframework.spek2.runtime.lifecycle.LifecycleManager
-import org.spekframework.spek2.runtime.lifecycle.MemoizedValueCreator
-import org.spekframework.spek2.runtime.lifecycle.MemoizedValueReader
+import org.spekframework.spek2.runtime.lifecycle.*
 import org.spekframework.spek2.runtime.scope.*
 
 class Collector(
@@ -63,6 +61,14 @@ class Collector(
 
     override fun <T> memoized(): MemoizedValue<T> {
         return MemoizedValueReader(root)
+    }
+
+    override fun <T> value(factory: () -> T): LetValue.PropertyCreator<T> {
+        return LetValueCreator(factory, this, { finalizers.add(it) })
+    }
+
+    override fun <T> value(letValue: LetValue<T>, factory: () -> T) {
+        (letValue as LetValueHolder).override(root.path, factory)
     }
 
     override fun registerListener(listener: LifecycleListener) {

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/lifecycle/LetValueCreator.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/lifecycle/LetValueCreator.kt
@@ -1,0 +1,77 @@
+package org.spekframework.spek2.runtime.lifecycle
+
+import org.spekframework.spek2.dsl.Root
+import org.spekframework.spek2.lifecycle.*
+import org.spekframework.spek2.runtime.Collector
+import org.spekframework.spek2.runtime.scope.GroupScopeImpl
+import org.spekframework.spek2.runtime.scope.Path
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+class LetValueCreator<T>(
+        val factory: () -> T, val root: Root, val afterGroupDeclaration: (() -> Unit) -> Unit
+) : LetValue.PropertyCreator<T> {
+    override fun provideDelegate(thisRef: Any?, property: KProperty<*>): ReadOnlyProperty<Any?, LetValue<T>> {
+        return LetValueHolder(factory, root, property.name).also {
+            root.registerListener(it)
+            root.beforeEachTest { it.inTest = true }
+
+            // This causes the afterEachTest to run last in the declaring group.
+            afterGroupDeclaration {
+                root.afterEachTest { it.reset() }
+            }
+        }
+    }
+}
+
+class LetValueHolder<T>(baseFactory: () -> T, val root: Root, val name: String) : LetValue<T>, LifecycleListener {
+    val paths = hashMapOf((root as Collector).root.path to baseFactory)
+    private var currentPath: Path? = null
+    private val stack = mutableListOf<Path?>()
+
+    var inTest: Boolean = false
+    private var initializedForTest = false
+    private var valueForTest: T? = null
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): LetValue<T> = this
+
+    override operator fun invoke(): T {
+        if (!inTest) throw IllegalStateException("$name() can't be used from beforeEachGroup or afterEachGroup")
+
+        if (initializedForTest) {
+            return valueForTest!!
+        }
+
+        var searchPath = currentPath
+        while (searchPath != null && !paths.containsKey(searchPath)) {
+            searchPath = searchPath.parent
+        }
+        val fn = paths[searchPath] ?: throw IllegalStateException("no let value for $currentPath")
+        return fn().also {
+            valueForTest = it
+            initializedForTest = true
+        }
+    }
+
+    fun override(path: Path, factory: () -> T) {
+        if (paths.containsKey(path)) {
+            throw IllegalStateException("value already given for $name in $path")
+        }
+        paths[path] = factory
+    }
+
+    fun reset() {
+        initializedForTest = false
+        valueForTest = null
+        inTest = false
+    }
+
+    override fun beforeExecuteGroup(group: GroupScope) {
+        stack.add(currentPath)
+        currentPath = (group as GroupScopeImpl).path
+    }
+
+    override fun afterExecuteGroup(group: GroupScope, result: ExecutionResult) {
+        currentPath = stack.removeAt(stack.size - 1)
+    }
+}

--- a/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/JvmDiscoveryContextFactory.kt
+++ b/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/JvmDiscoveryContextFactory.kt
@@ -46,7 +46,7 @@ object JvmDiscoveryContextFactory {
             .enableClassInfo()
 
         if (testDirs.isNotEmpty()) {
-            cg.overrideClasspath(System.getProperty("java.class.path"), testDirs)
+            cg.overrideClasspath(System.getProperty("java.class.path"), *testDirs.toTypedArray())
         }
 
         return cg.scan().use {


### PR DESCRIPTION
Use
```kt
val varName by value { expression }
```
to declare a _let value_, and
```kt
value(varName) { expression }
```
to override its value within a context. Values are memoized per-test and accessed by invocation:
```kt
println(varName())
```

Fixes #807.