### PR TITLE
Fix "Test framework quit unexpectedly" error while running tests in IDE

### DIFF
--- a/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/JvmDiscoveryContextFactory.kt
+++ b/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/JvmDiscoveryContextFactory.kt
@@ -46,7 +46,7 @@ object JvmDiscoveryContextFactory {
             .enableClassInfo()
 
         if (testDirs.isNotEmpty()) {
-            cg.overrideClasspath(System.getProperty("java.class.path"), testDirs)
+            cg.overrideClasspath(System.getProperty("java.class.path"), *testDirs.toTypedArray())
         }
 
         return cg.scan().use {


### PR DESCRIPTION
When running a single test in IDE, versions 2.0.6-2.0.10 of Spek fail to discover any tests because any `testDirs` are ignored by classgraph.
@raniejade 