### PR TITLE
Drop support for old IJ and AS versions

### DIFF
--- a/.github/workflows/check-pr-as-plugin.yaml
+++ b/.github/workflows/check-pr-as-plugin.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        as_sdk: [AS33, AS34, AS35, AS36, AS40]
+        as_sdk: [AS35, AS36, AS40]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/check-pr-idea-plugin.yaml
+++ b/.github/workflows/check-pr-idea-plugin.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ij_sdk: [IJ182, IJ183, IJ191, IJ192, IJ193, IJ201, IJ202]
+        ij_sdk: [IJ193, IJ201, IJ202]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
   deploy_ij_plugin:
     strategy:
       matrix:
-        ij_sdk: [IJ182, IJ183, IJ191, IJ192, IJ193, IJ201, IJ202]
+        ij_sdk: [IJ193, IJ201, IJ202]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
   deploy_as_plugin:
     strategy:
       matrix:
-        as_sdk: [AS33, AS34, AS35, AS36, AS40]
+        as_sdk: [AS35, AS36, AS40]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/spek-ide-plugin-android-studio/build.gradle.kts
+++ b/spek-ide-plugin-android-studio/build.gradle.kts
@@ -6,20 +6,6 @@ plugins {
 }
 
 val buildMatrix = mapOf(
-    "AS33" to ij.BuildConfig(
-        "182.5107.16",
-        "Studio3.3",
-        "AS33",
-        ij.VersionRange("182.5107", "182.5107.*"),
-        arrayOf("org.jetbrains.kotlin:1.3.30-release-Studio3.3-1")
-    ),
-    "AS34" to ij.BuildConfig(
-        "183.6156.11",
-        "Studio3.4",
-        "AS34",
-        ij.VersionRange("183.6156", "183.6156.*"),
-        arrayOf("org.jetbrains.kotlin:1.3.30-release-Studio3.4-1")
-    ),
     "AS35" to ij.BuildConfig(
         "191.8026.42",
         "Studio3.5",

--- a/spek-ide-plugin-android-studio/build.gradle.kts
+++ b/spek-ide-plugin-android-studio/build.gradle.kts
@@ -29,7 +29,7 @@ val buildMatrix = mapOf(
     )
 )
 
-val sdkVersion = project.properties["as.version"] ?: "AS36"
+val sdkVersion = project.properties["as.version"] ?: "AS40"
 val settings = checkNotNull(buildMatrix[sdkVersion])
 
 intellij {

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -29,7 +29,7 @@ val buildMatrix = mapOf(
     )
 )
 
-val sdkVersion = project.properties["ij.version"] ?: "IJ192"
+val sdkVersion = project.properties["ij.version"] ?: "IJ202"
 val settings = checkNotNull(buildMatrix[sdkVersion])
 
 intellij {

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -6,34 +6,6 @@ plugins {
 }
 
 val buildMatrix = mapOf(
-    "IJ182" to ij.BuildConfig(
-        "2018.2.5",
-        "IJ2018.2",
-        "IJ182",
-        ij.VersionRange("182.1", "182.*"),
-        arrayOf("org.jetbrains.kotlin:1.3.30-release-IJ2018.2-1")
-    ),
-    "IJ183" to ij.BuildConfig(
-        "183.4284.36",
-        "IJ2018.3",
-        "IJ183",
-        ij.VersionRange("183.1", "183.*"),
-        arrayOf("org.jetbrains.kotlin:1.3.30-release-IJ2018.3-1")
-    ),
-    "IJ191" to ij.BuildConfig(
-        "2019.1",
-        "IJ2019.1",
-        "IJ183",
-        ij.VersionRange("191.1", "191.*"),
-        arrayOf("org.jetbrains.kotlin:1.3.31-release-IJ2019.1-1")
-    ),
-    "IJ192" to ij.BuildConfig(
-        "192-EAP-SNAPSHOT",
-        "IJ2019.2",
-        "IJ183",
-        ij.VersionRange("192.1", "192.*"),
-        arrayOf("java", "org.jetbrains.kotlin:1.3.40-release-IJ2019.2-1")
-    ),
     "IJ193" to ij.BuildConfig(
         "193.6015.39",
         "IJ2019.3",


### PR DESCRIPTION
The following versions are dropped:
- Android Studio 3.3
- Android Studio 3.4
- IntelliJ IDEA 2018.2
- IntelliJ IDEA 2018.3
- IntelliJ IDEA 2019.1
- IntelliJ IDEA 2019.2
