### PR TITLE
Distinguish user land CancellationException from runtime ones

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -41,7 +41,7 @@ kotlin {
       compilations["test"].defaultSourceSet {
         dependencies {
           runtimeOnly(kotlin("reflect"))
-          implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.4")
+          implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.7-1.4-M3")
           implementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0")
           implementation("org.mockito:mockito-core:2.23.4")
           runtimeOnly("org.spekframework.spek2:spek-runner-junit5")

--- a/spek-kotlin-compiler-plugin-native/src/main/kotlin/org/spekframework/spek2/kotlin/SpekExtension.kt
+++ b/spek-kotlin-compiler-plugin-native/src/main/kotlin/org/spekframework/spek2/kotlin/SpekExtension.kt
@@ -11,8 +11,6 @@ import org.jetbrains.kotlin.descriptors.findClassAcrossModuleDependencies
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.addField
-import org.jetbrains.kotlin.ir.builders.declarations.addProperty
-import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
@@ -25,17 +23,16 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrExpressionBodyImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrFunctionReferenceImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.classifierOrFail
+import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.util.dump
+import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 // TODO: this extension is broken starting from 1.3.7x
 class SpekExtension : IrGenerationExtension {
@@ -156,7 +153,9 @@ private class SpekCollector(
     }
 
     private val IrClass.isSpek: Boolean
-        get() = superTypes.any { it.classifierOrFail.descriptor.fqNameSafe.asString() == spekClassName }
+        get() = superTypes.any {
+            it.getClass()?.fqNameForIrSerialization?.asString() == spekClassName
+        }
 
     private val IrClass.isAbstract: Boolean
         get() = this.modality == Modality.ABSTRACT


### PR DESCRIPTION
This replaces `withTimeout` call in the executor with `withTimeoutOrNull`.