### PR TITLE
Publish kotlinMultiplatform publication

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -25,8 +25,8 @@ kotlin {
 
     val commonTest by getting {
       dependencies {
-        implementation("org.spekframework.spek2:spek-dsl-metadata")
-        implementation("org.spekframework.spek2:spek-runtime-metadata")
+        implementation("org.spekframework.spek2:spek-dsl")
+        implementation("org.spekframework.spek2:spek-runtime")
         implementation(kotlin("test"))
       }
     }
@@ -67,8 +67,6 @@ kotlin {
       compilations["test"].defaultSourceSet {
         dependencies {
           dependsOn(nativeTest)
-          implementation("org.spekframework.spek2:spek-dsl-linux")
-          implementation("org.spekframework.spek2:spek-runtime-linux")
         }
       }
     }
@@ -83,8 +81,6 @@ kotlin {
       compilations["test"].defaultSourceSet {
         dependencies {
           dependsOn(nativeTest)
-          implementation("org.spekframework.spek2:spek-dsl-macos")
-          implementation("org.spekframework.spek2:spek-runtime-macos")
         }
       }
     }
@@ -99,8 +95,6 @@ kotlin {
       compilations["test"].defaultSourceSet {
         dependencies {
           dependsOn(nativeTest)
-          implementation("org.spekframework.spek2:spek-dsl-windows")
-          implementation("org.spekframework.spek2:spek-runtime-windows")
         }
       }
     }

--- a/integration-test/settings.gradle.kts
+++ b/integration-test/settings.gradle.kts
@@ -1,11 +1,13 @@
 includeBuild("../") {
   dependencySubstitution {
     substitute(module("org.spekframework.spek2:spek-gradle-plugin:0.1.0")).with(project(":spek-gradle-plugin"))
+    substitute(module("org.spekframework.spek2:spek-dsl")).with(project(":spek-dsl"))
     substitute(module("org.spekframework.spek2:spek-dsl-metadata")).with(project(":spek-dsl"))
     substitute(module("org.spekframework.spek2:spek-dsl-jvm")).with(project(":spek-dsl"))
     substitute(module("org.spekframework.spek2:spek-dsl-linux")).with(project(":spek-dsl"))
     substitute(module("org.spekframework.spek2:spek-dsl-windows")).with(project(":spek-dsl"))
     substitute(module("org.spekframework.spek2:spek-dsl-macos")).with(project(":spek-dsl"))
+    substitute(module("org.spekframework.spek2:spek-runtime")).with(project(":spek-runtime"))
     substitute(module("org.spekframework.spek2:spek-runtime-metadata")).with(project(":spek-runtime"))
     substitute(module("org.spekframework.spek2:spek-runtime-jvm")).with(project(":spek-runtime"))
     substitute(module("org.spekframework.spek2:spek-runtime-linux")).with(project(":spek-runtime"))

--- a/spek-dsl/build.gradle.kts
+++ b/spek-dsl/build.gradle.kts
@@ -97,7 +97,7 @@ val stubJavaDocJar by tasks.registering(Jar::class) {
 }
 
 project.extra["artifacts"] = when (currentOS) {
-  OS.LINUX -> arrayOf("metadata", "jvm", "js", "linux")
+  OS.LINUX -> arrayOf("kotlinMultiplatform", "metadata", "jvm", "js", "linux")
   OS.WINDOWS -> arrayOf("windows")
   OS.MACOS -> arrayOf("macos")
 }
@@ -111,6 +111,13 @@ publishing {
     val targetPublication: Publication? = publications.findByName(target.name)
     if (targetPublication is MavenPublication) {
       targetPublication.artifact(stubJavaDocJar.get())
+    }
+  }
+
+  publications {
+    getByName("kotlinMultiplatform", MavenPublication::class) {
+      groupId = "org.spekframework.spek2"
+      artifactId = "spek-dsl"
     }
   }
 }

--- a/spek-runtime/build.gradle.kts
+++ b/spek-runtime/build.gradle.kts
@@ -102,7 +102,7 @@ val stubJavaDocJar by tasks.registering(Jar::class) {
 }
 
 project.extra["artifacts"] = when (currentOS) {
-    OS.LINUX -> arrayOf("metadata", "jvm", "js", "linux")
+    OS.LINUX -> arrayOf("kotlinMultiplatform", "metadata", "jvm", "js", "linux")
     OS.WINDOWS -> arrayOf("windows")
     OS.MACOS -> arrayOf("macos")
 }
@@ -116,6 +116,13 @@ publishing {
         val targetPublication: Publication? = publications.findByName(target.name)
         if (targetPublication is MavenPublication) {
             targetPublication.artifact(stubJavaDocJar.get())
+        }
+    }
+
+    publications {
+        getByName("kotlinMultiplatform", MavenPublication::class) {
+            groupId = "org.spekframework.spek2"
+            artifactId = "spek-runtime"
         }
     }
 }


### PR DESCRIPTION
This will allow users to use `spek-dsl` and `spek-runtime` dependencies once without having to declare dependencies for each platform.