### PR TITLE
Make discovery of scopes concurrent

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -119,6 +119,8 @@ spek2 {
 tasks {
     afterEvaluate {
         val runSpekJvmTest by getting(Test::class) {
+            // enable concurrent discovery
+            systemProperty("spek2.discovery.concurrent", "")
             filter {
                 includeTestsMatching("org.spekframework.spek2.*")
             }

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
@@ -46,7 +46,7 @@ class SpekRuntime {
         val scopes = mutableListOf<GroupScopeImpl>()
         val time = measureTime {
             doRunBlocking {
-                if (isEnableConcurrentDiscovery(false)) {
+                if (isConcurrentDiscoveryEnabled(false)) {
                     withContext(Dispatchers.Default) {
                         filterScopes(discoveryRequest).collect { scope ->
                             scopes.add(scope)
@@ -103,5 +103,5 @@ class SpekRuntime {
     }
 }
 
-expect fun isEnableConcurrentDiscovery(default: Boolean): Boolean
+expect fun isConcurrentDiscoveryEnabled(default: Boolean): Boolean
 expect fun getGlobalTimeoutSetting(default: Long): Long

--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
@@ -1,5 +1,9 @@
 package org.spekframework.spek2.runtime
 
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.lifecycle.CachingMode
@@ -9,24 +13,54 @@ import org.spekframework.spek2.runtime.execution.ExecutionRequest
 import org.spekframework.spek2.runtime.lifecycle.LifecycleManager
 import org.spekframework.spek2.runtime.scope.*
 import org.spekframework.spek2.runtime.util.ClassUtil
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTime
 
 class SpekRuntime {
+    private suspend fun CoroutineScope.filterScopes(discoveryRequest: DiscoveryRequest): Flow<GroupScopeImpl> = flow {
+        val tasks = mutableListOf<Deferred<GroupScopeImpl?>>()
+        discoveryRequest.context.getTests().forEach { testInfo ->
+            val matchingPath = discoveryRequest.paths.firstOrNull { it.intersects(testInfo.path) }
+            if (matchingPath != null) {
+                val task = async {
+                    val spec = resolveSpec(testInfo.createInstance(), testInfo.path)
+                    spec.filterBy(matchingPath)
+                    if (!spec.isEmpty()) {
+                        spec
+                    } else {
+                        null
+                    }
+
+                }
+                tasks.add(task)
+            }
+        }
+
+        tasks.forEach { task ->
+            task.await()?.let { emit(it) }
+        }
+    }
+
+    @UseExperimental(ExperimentalTime::class)
     fun discover(discoveryRequest: DiscoveryRequest): DiscoveryResult {
-        val scopes = discoveryRequest.context.getTests()
-            .map { testInfo ->
-                val matchingPath = discoveryRequest.paths.firstOrNull { it.intersects(testInfo.path) }
-                testInfo to matchingPath
+        val scopes = mutableListOf<GroupScopeImpl>()
+        val time = measureTime {
+            doRunBlocking {
+                if (isEnableConcurrentDiscovery(false)) {
+                    withContext(Dispatchers.Default) {
+                        filterScopes(discoveryRequest).collect { scope ->
+                            scopes.add(scope)
+                        }
+                    }
+                } else {
+                    filterScopes(discoveryRequest).collect { scope ->
+                        scopes.add(scope)
+                    }
+                }
             }
-            .filter { (_, matchingPath) -> matchingPath != null }
-            .map { (testInfo, matchingPath) ->
-                checkNotNull(matchingPath)
-                val spec = resolveSpec(testInfo.createInstance(), testInfo.path)
-                spec.filterBy(matchingPath)
-                spec
-            }
-            .filter { spec -> !spec.isEmpty() }
+        }
 
-
+        println("Spek discovery completed in ${time.inMilliseconds} ms")
         return DiscoveryResult(scopes)
     }
 
@@ -69,4 +103,5 @@ class SpekRuntime {
     }
 }
 
+expect fun isEnableConcurrentDiscovery(default: Boolean): Boolean
 expect fun getGlobalTimeoutSetting(default: Long): Long

--- a/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
+++ b/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
@@ -8,6 +8,6 @@ actual fun getGlobalTimeoutSetting(default: Long): Long {
     return override ?: default
 }
 
-actual fun isEnableConcurrentDiscovery(default: Boolean): Boolean {
+actual fun isConcurrentDiscoveryEnabled(default: Boolean): Boolean {
     return System.getProperty("spek2.discovery.concurrent") != null || default
 }

--- a/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
+++ b/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
@@ -1,6 +1,13 @@
 package org.spekframework.spek2.runtime
 
 actual fun getGlobalTimeoutSetting(default: Long): Long {
-    val override = System.getProperty("SPEK_TIMEOUT")?.toLong()
+    var override = System.getProperty("SPEK_TIMEOUT")?.toLong()
+    if (override == null) {
+        override = System.getProperty("spek2.timeout")?.toLong()
+    }
     return override ?: default
+}
+
+actual fun isEnableConcurrentDiscovery(default: Boolean): Boolean {
+    return System.getProperty("spek2.discovery.concurrent") != null || default
 }

--- a/spek-runtime/src/nativeMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
+++ b/spek-runtime/src/nativeMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
@@ -3,3 +3,7 @@ package org.spekframework.spek2.runtime
 actual fun getGlobalTimeoutSetting(default: Long): Long {
     return default
 }
+
+actual fun isEnableConcurrentDiscovery(default: Boolean): Boolean {
+    return default
+}

--- a/spek-runtime/src/nativeMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
+++ b/spek-runtime/src/nativeMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
@@ -4,6 +4,6 @@ actual fun getGlobalTimeoutSetting(default: Long): Long {
     return default
 }
 
-actual fun isEnableConcurrentDiscovery(default: Boolean): Boolean {
+actual fun isConcurrentDiscoveryEnabled(default: Boolean): Boolean {
     return default
 }


### PR DESCRIPTION
Apparently, `Classgraph` scanning is already done in parallel - so instead of allowing to disable it, I just added a property that allows how concurrent it can be (passing `1` will effectively make the scan synchronous). The biggest change in this PR is with how scopes are filtered, previously it was always synchronous. Scope filtering can now be done asynchronously, the implementation under the hood uses Kotlin's coroutines. To enable the new behaviour, you can set the `spek2.discovery.concurrent` property. 