### PR TITLE
Remove verbose on cg scan and don't use MonoClock in jvm

### DIFF
--- a/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
+++ b/spek-runtime/src/commonMain/kotlin/org/spekframework/spek2/runtime/SpekRuntime.kt
@@ -14,7 +14,6 @@ import org.spekframework.spek2.runtime.lifecycle.LifecycleManager
 import org.spekframework.spek2.runtime.scope.*
 import org.spekframework.spek2.runtime.util.ClassUtil
 import kotlin.time.ExperimentalTime
-import kotlin.time.measureTime
 
 class SpekRuntime {
     private suspend fun CoroutineScope.filterScopes(discoveryRequest: DiscoveryRequest): Flow<GroupScopeImpl> = flow {
@@ -60,7 +59,7 @@ class SpekRuntime {
             }
         }
 
-        println("Spek discovery completed in ${time.inMilliseconds} ms")
+        println("Spek discovery completed in $time ms")
         return DiscoveryResult(scopes)
     }
 
@@ -105,3 +104,5 @@ class SpekRuntime {
 
 expect fun isConcurrentDiscoveryEnabled(default: Boolean): Boolean
 expect fun getGlobalTimeoutSetting(default: Long): Long
+
+expect fun measureTime(block: () -> Unit): Long

--- a/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/JvmDiscoveryContextFactory.kt
+++ b/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/JvmDiscoveryContextFactory.kt
@@ -50,7 +50,6 @@ object JvmDiscoveryContextFactory {
             .enableClassInfo()
             // any jar on the classpath won't be scanned
             .disableJarScanning()
-            .verbose()
 
         if (testDirs.isNotEmpty()) {
             cg.overrideClasspath(System.getProperty("java.class.path"), *testDirs.toTypedArray())

--- a/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
+++ b/spek-runtime/src/jvmMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
@@ -1,5 +1,7 @@
 package org.spekframework.spek2.runtime
 
+import kotlin.system.measureTimeMillis
+
 actual fun getGlobalTimeoutSetting(default: Long): Long {
     var override = System.getProperty("SPEK_TIMEOUT")?.toLong()
     if (override == null) {
@@ -10,4 +12,8 @@ actual fun getGlobalTimeoutSetting(default: Long): Long {
 
 actual fun isConcurrentDiscoveryEnabled(default: Boolean): Boolean {
     return System.getProperty("spek2.discovery.concurrent") != null || default
+}
+
+actual fun measureTime(block: () -> Unit): Long {
+    return measureTimeMillis(block)
 }

--- a/spek-runtime/src/nativeMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
+++ b/spek-runtime/src/nativeMain/kotlin/org/spekframework/spek2/runtime/timeout.kt
@@ -1,9 +1,18 @@
 package org.spekframework.spek2.runtime
 
+import kotlin.time.ExperimentalTime
+import kotlin.time.MonoClock
+import kotlin.time.measureTime
+
 actual fun getGlobalTimeoutSetting(default: Long): Long {
     return default
 }
 
 actual fun isConcurrentDiscoveryEnabled(default: Boolean): Boolean {
     return default
+}
+
+@UseExperimental(ExperimentalTime::class)
+actual fun measureTime(block: () -> Unit): Long {
+    return MonoClock.measureTime(block).inMilliseconds.toLong()
 }


### PR DESCRIPTION
//cc @arturbosch