### PR TITLE
Fix docs about CachingMode

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -148,11 +148,11 @@ beforeEachTest {
 You can pass in an optional parameter to `memoized` which controls how the values are cached.
 
 - `CachingMode.TEST`: each test scope will receive a unique instance, this is the default.
-- `CachingMode.GROUP`: each group scope will receive a unique instance.
+- `CachingMode.EACH_GROUP`: each group scope will receive a unique instance.
 - `CachingMode.SCOPE`: effectively a singleton.
 - `CachingMode.INHERIT`: internal use only.
 
-If you are using the [gherkin](gherkin.md) style note that the default caching mode is `CachingMode.GROUP`.
+If you are using the [gherkin](gherkin.md) style note that the default caching mode is `CachingMode.EACH_GROUP`.
 
 ### Share common logic between tests
 Often there is some code, which needs to be called repeatedly before and after tests.

--- a/docs/gherkin.md
+++ b/docs/gherkin.md
@@ -63,7 +63,7 @@ Describes a business rule, it consists of a list of steps.
 - `And`: Can be used as an alternative to additional `Given`, `When`, or `Then` steps.
 
 ## Scope values
-The default caching mode for `memoized` is `CachingMode.GROUP`, which means that every scenario will have a unique instance.
+The default caching mode for `memoized` is `CachingMode.EACH_GROUP`, which means that every scenario will have a unique instance.
 
 ## Best practices
 ### Validating a side-effect


### PR DESCRIPTION
`CachingMode.GROUP` was replaced with `CachingMode.EACH_GROUP`, but remains in docs.