### PR TITLE
For Spek runner we should use testRuntimeOnly

### DIFF
--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -65,7 +65,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version'
 
     testImplementation 'org.spekframework.spek2:spek-dsl-jvm:$spek_version'
-    testImplementation 'org.spekframework.spek2:spek-runner-junit5:$spek_version'
+    testRuntimeOnly 'org.spekframework.spek2:spek-runner-junit5:$spek_version'
     // spek requires kotlin-reflect, can be omitted if already in the classpath
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }


### PR DESCRIPTION
When I use Spek runner in project `lib module 1` and trying to use JUnit5 standard tests in adjacent `lib module 2` (it depends on `lib module 1`) Android Studio can't run it by itself (using Gradle task it works well).
The error message:
```Text
Internal Error occurred.
org.junit.platform.commons.JUnitException: TestEngine with ID 'spek2' failed to discover tests
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:111)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:85)
	at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:92)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)
	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)
Caused by: java.lang.NoClassDefFoundError: org/spekframework/spek2/runtime/scope/PathBuilder
	at org.spekframework.spek2.junit.SpekTestEngine.discover(SpekTestEngine.kt:88)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:103)
	... 7 more
Caused by: java.lang.ClassNotFoundException: org.spekframework.spek2.runtime.scope.PathBuilder
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 9 more
```
To make it work we just need to replace `testImplementation` with `testRuntimeOnly` in dependencies section for Spek runner (file `build.gradle`)