### PR TITLE
[2.x] Add support for IJ 2021.2

### DIFF
--- a/.github/workflows/check-pr-idea-plugin.yaml
+++ b/.github/workflows/check-pr-idea-plugin.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211]
+        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211]
+        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -46,11 +46,11 @@ val buildMatrix = mapOf(
         "IJ2021.2",
         "IJ183",
         ij.VersionRange("212.1", "212.*"),
-        arrayOf("java", "org.jetbrains.kotlin:212-1.4.32-release-IJ4235")
+        arrayOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6693.43")
     )
 )
 
-val sdkVersion = project.properties["ij.version"] ?: "IJ211"
+val sdkVersion = project.properties["ij.version"] ?: "IJ212"
 val settings = checkNotNull(buildMatrix[sdkVersion])
 
 intellij {

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -40,6 +40,13 @@ val buildMatrix = mapOf(
         "IJ183",
         ij.VersionRange("211.1", "211.*"),
         arrayOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6556.4")
+    ),
+	"IJ212" to ij.BuildConfig(
+        "212.4746.92",
+        "IJ2021.2",
+        "IJ183",
+        ij.VersionRange("212.1", "212.*"),
+        arrayOf("java", "org.jetbrains.kotlin:212-1.4.32-release-IJ4235")
     )
 )
 


### PR DESCRIPTION
Upgrade plugin's supporting versions following the release of `IDEA 2021.2`