### PR TITLE
[2.0.x] Add support for IJ 2021.2

### DIFF
--- a/.github/workflows/check-pr-idea-plugin.yaml
+++ b/.github/workflows/check-pr-idea-plugin.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ij_sdk: [IJ193, IJ201, IJ202, IJ203]
+        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211]
+        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ reckon {
 
 allprojects {
     repositories {
+        mavenCentral()
         jcenter()
     }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    api(kotlin("gradle-plugin", version = "1.3.61"))
+    api(kotlin("gradle-plugin", version = "1.4.32"))
     api("org.jetbrains.dokka:dokka-gradle-plugin:0.9.17")
     api("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
     api("gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.10")

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,9 +16,8 @@ object Dependencies {
     val mockitoCore = "org.mockito:mockito-core:2.23.4"
     val mockitoInline = "org.mockito:mockito-inline:2.23.4"
 
-    val kotlinCoroutinesCoreCommon = "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:1.3.3"
-    val kotlinCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3"
-    val kotlinCoroutinesNative = "org.jetbrains.kotlinx:kotlinx-coroutines-core-native:1.3.3"
+    val kotlinCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
+    val kotlinCoroutinesNative = "org.jetbrains.kotlinx:kotlinx-coroutines-core-native:1.4.3"
 
     val autoService = "com.google.auto.service:auto-service:1.0-rc4"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -139,7 +139,5 @@ tasks {
 configurations.forEach {
     it.resolutionStrategy.dependencySubstitution {
         substitute(module("org.spekframework.spek2:spek-runtime")).with(project(":spek-runtime"))
-        substitute(module("org.spekframework.spek2:spek-kotlin-compiler-plugin-jvm")).with(project(":spek-kotlin-compiler-plugin-jvm"))
-        substitute(module("org.spekframework.spek2:spek-kotlin-compiler-plugin-native")).with(project(":spek-kotlin-compiler-plugin-native"))
     }
 }

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -3,12 +3,16 @@ plugins {
     id("org.spekframework.spek2.multiplatform")
 }
 
+repositories {
+    mavenCentral()
+}
+
 kotlin {
     metadata {}
     jvm {}
-    linuxX64("linux") {}
-    macosX64("macos") {}
-    mingwX64("windows") {}
+//    linuxX64("linux") {}
+//    macosX64("macos") {}
+//    mingwX64("windows") {}
 
     sourceSets {
         val commonMain by getting {
@@ -42,69 +46,69 @@ kotlin {
             }
         }
 
-        val nativeMain by creating {
-            dependsOn(commonMain)
-        }
-
-        val nativeTest by creating {
-            dependsOn(commonTest)
-        }
-
-        linuxX64("linux") {
-            compilations["main"].defaultSourceSet {
-                dependencies {
-                    dependsOn(nativeMain)
-                }
-            }
-
-            compilations["test"].defaultSourceSet {
-                dependencies {
-                    dependsOn(nativeTest)
-                }
-            }
-        }
-
-        linuxX64("linux") {
-            compilations["main"].defaultSourceSet {
-                dependencies {
-                    dependsOn(nativeMain)
-                }
-            }
-
-            compilations["test"].defaultSourceSet {
-                dependencies {
-                    dependsOn(nativeTest)
-                }
-            }
-        }
-
-        macosX64("macos") {
-            compilations["main"].defaultSourceSet {
-                dependencies {
-                    dependsOn(nativeMain)
-                }
-            }
-
-            compilations["test"].defaultSourceSet {
-                dependencies {
-                    dependsOn(nativeTest)
-                }
-            }
-        }
-
-        mingwX64("windows") {
-            compilations["main"].defaultSourceSet {
-                dependencies {
-                    dependsOn(nativeMain)
-                }
-            }
-
-            compilations["test"].defaultSourceSet {
-                dependencies {
-                    dependsOn(nativeTest)
-                }
-            }
-        }
+//        val nativeMain by creating {
+//            dependsOn(commonMain)
+//        }
+//
+//        val nativeTest by creating {
+//            dependsOn(commonTest)
+//        }
+//
+//        linuxX64("linux") {
+//            compilations["main"].defaultSourceSet {
+//                dependencies {
+//                    dependsOn(nativeMain)
+//                }
+//            }
+//
+//            compilations["test"].defaultSourceSet {
+//                dependencies {
+//                    dependsOn(nativeTest)
+//                }
+//            }
+//        }
+//
+//        linuxX64("linux") {
+//            compilations["main"].defaultSourceSet {
+//                dependencies {
+//                    dependsOn(nativeMain)
+//                }
+//            }
+//
+//            compilations["test"].defaultSourceSet {
+//                dependencies {
+//                    dependsOn(nativeTest)
+//                }
+//            }
+//        }
+//
+//        macosX64("macos") {
+//            compilations["main"].defaultSourceSet {
+//                dependencies {
+//                    dependsOn(nativeMain)
+//                }
+//            }
+//
+//            compilations["test"].defaultSourceSet {
+//                dependencies {
+//                    dependsOn(nativeTest)
+//                }
+//            }
+//        }
+//
+//        mingwX64("windows") {
+//            compilations["main"].defaultSourceSet {
+//                dependencies {
+//                    dependsOn(nativeMain)
+//                }
+//            }
+//
+//            compilations["test"].defaultSourceSet {
+//                dependencies {
+//                    dependsOn(nativeTest)
+//                }
+//            }
+//        }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 include("spek-dsl")
 include("spek-runtime")
 include("spek-runner-junit5")
-include("spek-kotlin-compiler-plugin-jvm")
-include("spek-kotlin-compiler-plugin-native")
+//include("spek-kotlin-compiler-plugin-jvm")
+//include("spek-kotlin-compiler-plugin-native")
 include("integration-test")
 
 val excludeIdePlugins: String? by settings

--- a/spek-gradle-plugin/src/main/kotlin/org/spekframework/spek2/gradle/domain/SpekTest.kt
+++ b/spek-gradle-plugin/src/main/kotlin/org/spekframework/spek2/gradle/domain/SpekTest.kt
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 
-class SpekTest(val name: String, objects: ObjectFactory) {
+open class SpekTest(val name: String, objects: ObjectFactory) {
     val target = objects.property(KotlinTarget::class.java)
     val compilation = objects.property(KotlinCompilation::class.java)
 

--- a/spek-gradle-plugin/src/main/kotlin/org/spekframework/spek2/gradle/entry/MultiplatformPlugin.kt
+++ b/spek-gradle-plugin/src/main/kotlin/org/spekframework/spek2/gradle/entry/MultiplatformPlugin.kt
@@ -91,7 +91,7 @@ class MultiplatformPlugin : Plugin<Project> {
 
         kotlinMppExtension.targets.all {
             when (this) {
-                is KotlinNativeTargetWithTests, is KotlinJvmTarget -> {
+                is KotlinNativeTargetWithTests<*>, is KotlinJvmTarget -> {
                     project.tasks.create("${this.name}SpekTests") {
                         group = VERIFICATION_GROUP
                         description = "Run Spek tests for target ${this@all.name}."

--- a/spek-gradle-plugin/src/main/kotlin/org/spekframework/spek2/gradle/kotlin/Subplugin.kt
+++ b/spek-gradle-plugin/src/main/kotlin/org/spekframework/spek2/gradle/kotlin/Subplugin.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 import org.spekframework.spek2.gradle.entry.MultiplatformPlugin
 import org.spekframework.spek2.gradle.domain.MultiplatformExtension
 
-@AutoService(KotlinGradleSubplugin::class)
 class Subplugin : KotlinGradleSubplugin<AbstractCompile> {
     override fun apply(project: Project, kotlinCompile: AbstractCompile, javaCompile: AbstractCompile?, variantData: Any?, androidProjectHandler: Any?, kotlinCompilation: KotlinCompilation<KotlinCommonOptions>?): List<SubpluginOption> {
         val extension = checkNotNull(project.extensions.findByType(MultiplatformExtension::class.java))

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -46,11 +46,11 @@ val buildMatrix = mapOf(
         "IJ2021.2",
         "IJ183",
         ij.VersionRange("212.1", "212.*"),
-        arrayOf("java", "org.jetbrains.kotlin:212-1.4.32-release-IJ4235")
+        arrayOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6693.43")
     )
 )
 
-val sdkVersion = project.properties["ij.version"] ?: "IJ211"
+val sdkVersion = project.properties["ij.version"] ?: "IJ212"
 val settings = checkNotNull(buildMatrix[sdkVersion])
 
 intellij {

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -40,6 +40,13 @@ val buildMatrix = mapOf(
         "IJ183",
         ij.VersionRange("211.1", "211.*"),
         arrayOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6556.4")
+    ),
+	"IJ212" to ij.BuildConfig(
+        "212.4746.92",
+        "IJ2021.2",
+        "IJ183",
+        ij.VersionRange("212.1", "212.*"),
+        arrayOf("java", "org.jetbrains.kotlin:212-1.4.32-release-IJ4235")
     )
 )
 

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -46,7 +46,7 @@ val buildMatrix = mapOf(
         "IJ2021.2",
         "IJ183",
         ij.VersionRange("212.1", "212.*"),
-        arrayOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6693.43")
+        arrayOf("java", "org.jetbrains.kotlin:212-1.4.32-release-IJ2230")
     )
 )
 

--- a/spek-runtime/build.gradle.kts
+++ b/spek-runtime/build.gradle.kts
@@ -65,7 +65,7 @@ kotlin {
             dependencies {
                 api(project(":spek-dsl"))
                 implementation(kotlin("stdlib-common"))
-                implementation(Dependencies.kotlinCoroutinesCoreCommon)
+                implementation(Dependencies.kotlinCoroutinesCore)
             }
         }
         


### PR DESCRIPTION
cc @eacheble.

I had to do several things to make it work, but mostly because they are needed to upgrade to Kotlin 1.4.