### PR TITLE
Provide sample versions for Kotlin and Spek.

### DIFF
--- a/docs/setup-jvm.md
+++ b/docs/setup-jvm.md
@@ -6,6 +6,10 @@ Gradle `4.7` or higher is recommended as it added a built-in support for JUnit P
 Groovy config:
 
 ```groovy
+
+def kotlin_version = '1.4.20'
+def spek_version = '2.0.17'
+
 // setup dependencies
 dependencies {
     // some version of Kotlin


### PR DESCRIPTION
The setup code misses the values for the variables. This makes the example not directly usable in the project.
I think providing sample values will be beneficiary for the readers of the documentation.