### PR TITLE
[2.x] Add support for IJ 2021.3

### DIFF
--- a/.github/workflows/check-pr-idea-plugin.yaml
+++ b/.github/workflows/check-pr-idea-plugin.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212]
+        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212, IJ213]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212]
+        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212, IJ213]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,6 @@ reckon {
 allprojects {
     repositories {
         jcenter()
-        maven ("https://dl.bintray.com/kotlin/kotlin-eap")
-        maven ("https://kotlin.bintray.com/kotlinx")
     }
 
     if (Files.exists(Paths.get("$rootDir/local.properties"))) {

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 
 repositories {
   jcenter()
-  maven ("https://dl.bintray.com/kotlin/kotlin-eap")
-  maven ("https://kotlin.bintray.com/kotlinx")
 }
 
 kotlin {

--- a/integration-test/settings.gradle.kts
+++ b/integration-test/settings.gradle.kts
@@ -12,8 +12,6 @@ includeBuild("../") {
 pluginManagement {
   repositories {
     jcenter()
-    maven ("https://dl.bintray.com/kotlin/kotlin-eap")
-    maven ("https://kotlin.bintray.com/kotlinx")
   }
   resolutionStrategy.eachPlugin {
     if (requested.id.id == "org.spekframework.spek2.multiplatform") {

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -58,6 +58,7 @@ val buildMatrix = mapOf(
 )
 
 val sdkVersion = project.properties["ij.version"] ?: "IJ213"
+
 val settings = checkNotNull(buildMatrix[sdkVersion])
 
 intellij {

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -49,11 +49,11 @@ val buildMatrix = mapOf(
         arrayOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6693.43")
     ),
     "IJ213" to ij.BuildConfig(
-        "213.5744.223",
+        "213.6461.79",
         "IJ2021.3",
         "IJ183",
         ij.VersionRange("213.1", "213.*"),
-        arrayOf("java", "org.jetbrains.kotlin:211-1.4.32-release-IJ6693.72")
+        arrayOf("java", "org.jetbrains.kotlin:213-1.6.10-release-944-IJ6461.79")
     )
 )
 

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -41,16 +41,23 @@ val buildMatrix = mapOf(
         ij.VersionRange("211.1", "211.*"),
         arrayOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6556.4")
     ),
-	"IJ212" to ij.BuildConfig(
+    "IJ212" to ij.BuildConfig(
         "212.4746.92",
         "IJ2021.2",
         "IJ183",
         ij.VersionRange("212.1", "212.*"),
         arrayOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6693.43")
+    ),
+    "IJ213" to ij.BuildConfig(
+        "213.5744.223",
+        "IJ2021.3",
+        "IJ183",
+        ij.VersionRange("213.1", "213.*"),
+        arrayOf("java", "org.jetbrains.kotlin:211-1.4.32-release-IJ6693.72")
     )
 )
 
-val sdkVersion = project.properties["ij.version"] ?: "IJ212"
+val sdkVersion = project.properties["ij.version"] ?: "IJ213"
 val settings = checkNotNull(buildMatrix[sdkVersion])
 
 intellij {


### PR DESCRIPTION
Upgrade plugin's supporting versions following the release of `IDEA 2021.3`

Based on https://github.com/spekframework/spek/pull/977