### PR TITLE
Update Kotlin, gradle-intellij-plugin and add support for IJ 2021.3

### DIFF
--- a/.github/workflows/check-pr-idea-plugin.yaml
+++ b/.github/workflows/check-pr-idea-plugin.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212]
+        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212, IJ213]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212]
+        ij_sdk: [IJ193, IJ201, IJ202, IJ203, IJ211, IJ212, IJ213]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,14 +5,14 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     gradlePluginPortal()
 }
 
 dependencies {
-    api(kotlin("gradle-plugin", version = "1.4.32"))
+    api(kotlin("gradle-plugin", version = "1.5.31"))
     api("org.jetbrains.dokka:dokka-gradle-plugin:0.9.17")
     api("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
-    api("gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.10")
+    api("org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.4.0")
     api("com.github.jengelman.gradle.plugins:shadow:4.0.2")
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,7 +16,7 @@ object Dependencies {
     val mockitoCore = "org.mockito:mockito-core:2.23.4"
     val mockitoInline = "org.mockito:mockito-inline:2.23.4"
 
-    val kotlinCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
+    val kotlinCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
 
     val autoService = "com.google.auto.service:auto-service:1.0-rc4"
 }

--- a/buildSrc/src/main/kotlin/ij/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/ij/BuildConfig.kt
@@ -7,5 +7,5 @@ data class BuildConfig(
     val prefix: String,
     val extraSource: String,
     val version: VersionRange,
-    val deps: Array<String> = emptyArray()
+    val deps: List<String> = emptyList()
 )

--- a/buildSrc/src/main/kotlin/publish-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-plugin.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.intellij.tasks.PublishTask
-
 val channel = if (project.extra["releaseMode"] == true) {
     "default"
 } else {
@@ -8,9 +6,7 @@ val channel = if (project.extra["releaseMode"] == true) {
 
 val publishToken = propOrEnv("HUB_API_TOKEN")
 
-tasks {
-    withType(PublishTask::class) {
-        setToken(publishToken)
-        setChannels(channel)
-    }
-}
+//publishPlugin {
+//    token = publishToken
+//    channels = [channel]
+//}

--- a/buildSrc/src/main/kotlin/publish-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-plugin.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.intellij.tasks.PublishPluginTask
+
 val channel = if (project.extra["releaseMode"] == true) {
     "default"
 } else {
@@ -6,7 +8,9 @@ val channel = if (project.extra["releaseMode"] == true) {
 
 val publishToken = propOrEnv("HUB_API_TOKEN")
 
-//publishPlugin {
-//    token = publishToken
-//    channels = [channel]
-//}
+tasks {
+    withType(PublishPluginTask::class) {
+        token.set(publishToken)
+        channels.set(listOf(channel))
+    }
+}

--- a/spek-gradle-plugin/build.gradle.kts
+++ b/spek-gradle-plugin/build.gradle.kts
@@ -1,12 +1,13 @@
 plugins {
-    id("org.ajoberstar.reckon") version "0.8.0"
     `kotlin-dsl`
-    kotlin("kapt") version "1.3.61"
+    kotlin("kapt") version "1.5.31"
+    id("org.ajoberstar.reckon") version "0.8.0"
+
 }
 
 buildscript {
     dependencies {
-        classpath(kotlin("gradle-plugin", version = "1.3.61"))
+        classpath(kotlin("gradle-plugin", version = "1.5.31"))
     }
 }
 

--- a/spek-gradle-plugin/src/main/kotlin/org/spekframework/spek2/gradle/task/ExecSpekTests.kt
+++ b/spek-gradle-plugin/src/main/kotlin/org/spekframework/spek2/gradle/task/ExecSpekTests.kt
@@ -1,12 +1,15 @@
 package org.spekframework.spek2.gradle.task
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 
 open class ExecSpekTests: DefaultTask() {
+    @Input
     val target = project.objects.property(KotlinTarget::class.java)
+    @Input
     val compilation = project.objects.property(KotlinCompilation::class.java)
 
     @TaskAction

--- a/spek-ide-plugin-android-studio/build.gradle.kts
+++ b/spek-ide-plugin-android-studio/build.gradle.kts
@@ -11,28 +11,28 @@ val buildMatrix = mapOf(
         "Studio3.6",
         "AS34",
         ij.VersionRange("192.7142.36", "192.7142.36.*"),
-        arrayOf("android", "java", "org.jetbrains.kotlin:1.3.61-release-Studio3.6-1")
+        listOf("android", "java", "org.jetbrains.kotlin:1.3.61-release-Studio3.6-1")
     ),
     "AS40" to ij.BuildConfig(
         "193.6911.18",
         "Studio4.0",
         "AS34",
         ij.VersionRange("193.6911.18", "193.6911.18.*"),
-        arrayOf("android", "java", "org.jetbrains.kotlin:1.3.70-release-Studio4.0-1")
+        listOf("android", "java", "org.jetbrains.kotlin:1.3.70-release-Studio4.0-1")
     ),
     "AS41" to ij.BuildConfig(
         "201.7223.91",
         "Studio4.1",
         "AS34",
         ij.VersionRange("201.8743.12", "201.8743.12.*"),
-        arrayOf("android", "java", "org.jetbrains.kotlin:1.3.72-release-Studio4.1-5")
+        listOf("android", "java", "org.jetbrains.kotlin:1.3.72-release-Studio4.1-5")
     ),
     "AS42" to ij.BuildConfig(
         "202.7660.26",
         "Studio4.2",
         "AS34",
         ij.VersionRange("202.7660.26", "202.7660.26.*"),
-        arrayOf("android", "java", "org.jetbrains.kotlin:1.4.10-release-Studio4.2-1")
+        listOf("android", "java", "org.jetbrains.kotlin:1.4.10-release-Studio4.2-1")
     )
 )
 
@@ -40,10 +40,9 @@ val sdkVersion = project.properties["as.version"] ?: "AS42"
 val settings = checkNotNull(buildMatrix[sdkVersion])
 
 intellij {
-    pluginName = "Spek Framework"
-    val plugins = arrayOf("gradle", "android") + settings.deps
-    setPlugins(*plugins)
-    version = settings.sdk
+    pluginName.set("Spek Framework")
+    plugins.set(listOf("gradle", "android") + settings.deps)
+    version.set(settings.sdk)
 }
 
 sourceSets {
@@ -73,8 +72,12 @@ tasks {
 
     patchPluginXml {
         setVersion("${project.version}-${settings.prefix}")
-        setSinceBuild(settings.version.since)
-        setUntilBuild(settings.version.until)
+        sinceBuild.set(settings.version.since)
+        untilBuild.set(settings.version.until)
+    }
+
+    buildSearchableOptions {
+        enabled = false
     }
 }
 

--- a/spek-ide-plugin-intellij-base-jvm/build.gradle.kts
+++ b/spek-ide-plugin-intellij-base-jvm/build.gradle.kts
@@ -4,9 +4,9 @@ plugins {
 }
 
 intellij {
-    pluginName = "spek-base-jvm"
-    setPlugins("org.jetbrains.kotlin:1.3.30-release-IJ2018.1-1")
-    version = "2018.1"
+    pluginName.set("spek-base-jvm")
+    plugins.set(listOf("org.jetbrains.kotlin:1.3.61-release-IJ2018.3-1"))
+    version.set("2018.3")
 }
 
 dependencies {

--- a/spek-ide-plugin-intellij-base/build.gradle.kts
+++ b/spek-ide-plugin-intellij-base/build.gradle.kts
@@ -4,9 +4,9 @@ plugins {
 }
 
 intellij {
-    pluginName = "spek-base"
-    setPlugins("org.jetbrains.kotlin:1.3.30-release-IJ2018.1-1")
-    version = "2018.1"
+    pluginName.set("spek-base")
+    plugins.set(listOf("org.jetbrains.kotlin:1.3.61-release-IJ2018.3-1"))
+    version.set("2018.3")
 }
 
 dependencies {
@@ -24,6 +24,6 @@ tasks {
     }
 
     patchPluginXml {
-        setSinceBuild("181.*")
+        sinceBuild.set("181.*")
     }
 }

--- a/spek-ide-plugin-intellij-base/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
+++ b/spek-ide-plugin-intellij-base/src/main/kotlin/org/spekframework/intellij/SpekRunConfigurationProducer.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.idea.caches.project.implementingModules
 import org.jetbrains.kotlin.idea.core.getPackage
 import org.jetbrains.kotlin.idea.util.module
 import org.jetbrains.kotlin.platform.IdePlatformKind
+import org.jetbrains.kotlin.platform.idePlatformKind
 import org.jetbrains.kotlin.platform.impl.CommonIdePlatformKind
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -103,22 +104,22 @@ abstract class SpekRunConfigurationProducer(val producerType: ProducerType, type
             if (path != null) {
                 configuration.data.path = path
                 configuration.data.generatedNameHint = nameHint
-                val kotlinFacetSettings = KotlinFacetSettingsProvider.getInstance(context.project)
+                val kotlinFacetSettings = KotlinFacetSettingsProvider.getInstance(context.project)!!
                         .getInitializedSettings(context.module)
 
 
                 var canRun = false
-                if (isPlatformSupported(kotlinFacetSettings.platform!!.kind)) {
+                if (isPlatformSupported(kotlinFacetSettings.targetPlatform!!.idePlatformKind)) {
                     configuration.configureForModule(context.module)
                     configuration.data.producerType = producerType
                     canRun = true
                     configuration.data.producerType = producerType
-                } else if (kotlinFacetSettings.platform!!.kind == CommonIdePlatformKind) {
+                } else if (kotlinFacetSettings.targetPlatform!!.idePlatformKind == CommonIdePlatformKind) {
                     val result = findSupportedModule(context.project, context.module)
                     if (result != null) {
                         val (module, moduleKotlinFacetSettings) = result
                         configuration.configureForModule(module)
-                        configuration.data.producerType = moduleKotlinFacetSettings.platform!!.kind.toProducerType()
+                        configuration.data.producerType = moduleKotlinFacetSettings.targetPlatform!!.idePlatformKind.toProducerType()
                         canRun = true
                     }
                 }
@@ -153,11 +154,11 @@ abstract class SpekRunConfigurationProducer(val producerType: ProducerType, type
     }
 
     private fun findSupportedModule(project: Project, commonModule: Module): Pair<Module, KotlinFacetSettings>? {
-        val kotlinFacetSettingsProvider = KotlinFacetSettingsProvider.getInstance(project)
+        val kotlinFacetSettingsProvider = KotlinFacetSettingsProvider.getInstance(project)!!
         return commonModule.implementingModules
             .map { it to kotlinFacetSettingsProvider.getInitializedSettings(it) }
             .firstOrNull {
-                isPlatformSupported(it.second.platform!!.kind)
+                isPlatformSupported(it.second.targetPlatform!!.idePlatformKind)
             }
     }
 

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -11,52 +11,54 @@ val buildMatrix = mapOf(
         "IJ2019.3",
         "IJ183",
         ij.VersionRange("193.1", "193.*"),
-        arrayOf("java", "org.jetbrains.kotlin:1.3.50-release-IJ2019.2-1")
-    ),
-    "IJ201" to ij.BuildConfig(
+        listOf("java", "org.jetbrains.kotlin:1.3.50-release-IJ2019.2-1")
+    ), "IJ201" to ij.BuildConfig(
         "201.8743.12",
         "IJ2020.1",
         "IJ183",
         ij.VersionRange("201.1", "201.*"),
-        arrayOf("java", "org.jetbrains.kotlin:1.3.61-release-IJ2019.3-1")
-    ),
-    "IJ202" to ij.BuildConfig(
+        listOf("java", "org.jetbrains.kotlin:1.3.61-release-IJ2019.3-1")
+    ), "IJ202" to ij.BuildConfig(
         "202.8194.7",
         "IJ2020.2",
         "IJ183",
         ij.VersionRange("202.1", "202.*"),
-        arrayOf("java", "org.jetbrains.kotlin:1.3.72-release-IJ2020.1-5")
-    ),
-    "IJ203" to ij.BuildConfig(
+        listOf("java", "org.jetbrains.kotlin:1.3.72-release-IJ2020.1-5")
+    ), "IJ203" to ij.BuildConfig(
         "203.5981.155",
         "IJ2020.3",
         "IJ183",
         ij.VersionRange("203.1", "203.*"),
-        arrayOf("java", "org.jetbrains.kotlin:1.4.0-release-IJ2020.2-1")
-    ),
-    "IJ211" to ij.BuildConfig(
+        listOf("java", "org.jetbrains.kotlin:1.4.0-release-IJ2020.2-1")
+    ), "IJ211" to ij.BuildConfig(
         "211-EAP-SNAPSHOT",
         "IJ2021.1",
         "IJ183",
         ij.VersionRange("211.1", "211.*"),
-        arrayOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6556.4")
-    ),
-	"IJ212" to ij.BuildConfig(
+        listOf("java", "org.jetbrains.kotlin:211-1.4.21-release-IJ6556.4")
+    ), "IJ212" to ij.BuildConfig(
         "212.4746.92",
         "IJ2021.2",
         "IJ183",
         ij.VersionRange("212.1", "212.*"),
-        arrayOf("java", "org.jetbrains.kotlin:212-1.4.32-release-IJ2230")
+        listOf("java", "org.jetbrains.kotlin:212-1.4.32-release-IJ2230")
+    ),
+    "IJ213" to ij.BuildConfig(
+        "213.6461.79",
+        "IJ2021.3",
+        "IJ183",
+        ij.VersionRange("213.1", "213.*"),
+        listOf("java", "org.jetbrains.kotlin:213-1.6.10-release-944-IJ6461.79")
     )
 )
 
-val sdkVersion = project.properties["ij.version"] ?: "IJ212"
+val sdkVersion = project.properties["ij.version"] ?: "IJ213"
 val settings = checkNotNull(buildMatrix[sdkVersion])
 
 intellij {
-    pluginName = "Spek Framework"
-    setPlugins(*settings.deps)
-    version = settings.sdk
+    pluginName.set("Spek Framework")
+    plugins.set(settings.deps)
+    version.set(settings.sdk)
 }
 
 sourceSets {
@@ -86,8 +88,8 @@ tasks {
 
     patchPluginXml {
         setVersion("${project.version}-${settings.prefix}")
-        setSinceBuild(settings.version.since)
-        setUntilBuild(settings.version.until)
+        sinceBuild.set(settings.version.since)
+        untilBuild.set(settings.version.until)
     }
 }
 

--- a/spek-ide-plugin-intellij-idea/build.gradle.kts
+++ b/spek-ide-plugin-intellij-idea/build.gradle.kts
@@ -31,7 +31,7 @@ val buildMatrix = mapOf(
         ij.VersionRange("203.1", "203.*"),
         listOf("java", "org.jetbrains.kotlin:1.4.0-release-IJ2020.2-1")
     ), "IJ211" to ij.BuildConfig(
-        "211-EAP-SNAPSHOT",
+        "211.7628.21",
         "IJ2021.1",
         "IJ183",
         ij.VersionRange("211.1", "211.*"),

--- a/spek-ide-plugin-intellij-idea/src/main/kotlin/org/spekframework/intellij/SpekJvmConfigurationFactory.kt
+++ b/spek-ide-plugin-intellij-idea/src/main/kotlin/org/spekframework/intellij/SpekJvmConfigurationFactory.kt
@@ -9,4 +9,9 @@ import com.intellij.openapi.project.Project
 class SpekJvmConfigurationFactory(type: ConfigurationType): ConfigurationFactory(type) {
     override fun createTemplateConfiguration(project: Project): RunConfiguration =
         SpekJvmRunConfiguration("Un-named", JavaRunConfigurationModule(project, true), this)
+
+    override fun getId(): String {
+        // name is not localized
+        return name
+    }
 }


### PR DESCRIPTION
- Kotlin is upgraded to `1.5.31` (I haven't tried 1.6.0 yet so not sure how big the changes are gonna be), this upgrade is required so that it is easy to support IJ 2021.3. 
- Upgraded `gradle-intellij-plugin` so that we can build new versions of IJ plugins
- Finally, adds support for IJ 2021.3

This PR expands from #988.

Apologies for the delay and inconvenience this has caused. 
